### PR TITLE
Fix Org Member Sort

### DIFF
--- a/CmsWeb/Areas/Manage/Models/OrgMembersModel.cs
+++ b/CmsWeb/Areas/Manage/Models/OrgMembersModel.cs
@@ -209,7 +209,7 @@ namespace CmsWeb.Models
                             orderby om.Person.Name2
                             select om;
                         break;
-                    case "DOB":
+                    case "Date of Birth":
                         q = from om in q
                             orderby om.Person.BirthYear, om.Person.BirthMonth, om.Person.BirthDay
                             select om;
@@ -244,7 +244,7 @@ namespace CmsWeb.Models
                             orderby om.Person.Name2 descending
                             select om;
                         break;
-                    case "DOB":
+                    case "Date of Birth":
                         q = from om in q
                             orderby om.Person.BirthYear descending, om.Person.BirthMonth descending, om.Person.BirthDay descending
                             select om;


### PR DESCRIPTION
**Bug Fix**: Originally submitted via TPS Support Request  (gsbcfamily [5717])

**Solution**
The case condition in the Switch statement in ApplySort() should be "Date of Birth"
instead of "DOB" to match the column heading in
CmsWeb/Areas/Manage/Views/OrgMembers/List.cshtml
In the current live build, since it does not find "Date of Birth" it goes to the default which sorts by Name.
``` 
   default:
   case "Name":
```
**Testing**
I compared performance using same conditions on the life database and a downloaded database with the new build.  