### PR TITLE
Email Replacement Codes

### DIFF
--- a/CmsData/Email/EmailReplacements.cs
+++ b/CmsData/Email/EmailReplacements.cs
@@ -234,6 +234,12 @@ namespace CmsData
                 case "{dob}":
                     return p.DOB;
 
+                case "{estatement}":
+                    if (p.ElectronicStatement == true)
+                        return "Online Electronic Statement Only";
+                    else
+                        return "Printed Statement in Addition to Online Option";
+
                 case "{emailhref}":
                     if (emailqueueto != null)
                         return db.ServerLink("/EmailView/" + emailqueueto.Id);
@@ -281,6 +287,12 @@ namespace CmsData
                 case "{peopleid}":
                     return p.PeopleId.ToString();
 
+                case "{receivesms}":
+                    if (p.ReceiveSMS == true)
+                        return "Yes";
+                    else
+                        return "No";
+
                 case "{salutation}":
                     if (emailqueueto != null)
                         return db.GoerSupporters.Where(ee => ee.Id == emailqueueto.GoerSupportId).Select(ee => ee.Salutation).SingleOrDefault();
@@ -289,6 +301,22 @@ namespace CmsData
                 case "{state}":
                     return p.PrimaryState;
 
+                case "{statementtype}":
+                    var stmtcode = p.ContributionOptionsId;
+                    switch (stmtcode)
+                    {
+                        case CmsData.Codes.StatementOptionCode.Individual:
+                            return "Individual";
+
+                        case CmsData.Codes.StatementOptionCode.Joint:
+                            return "Joint";
+
+                        case CmsData.Codes.StatementOptionCode.None:
+                        default:
+                            return "None";
+                    }
+
+                    
                 case "{email}":
                 case "{toemail}":
                     if (ListAddresses.Count > 0)


### PR DESCRIPTION
I am preparing to send out a mass email to everyone that has contributions this year.  I would like to include their statement options in the email for reference.  And encourage them to go online to manage the options as well as to verify contributions and later print out their statements.

I added replacement codes for:
- Electronic Statements  (electronic only or paper)
     + {estatement}
          - "Online Electronic Statement Only"
          - "Printed Statement in Addition to Online Option"

- Statement Option (Indiv, joint, none)
     + {statementtype}
          - "Individual"
          - "Joint"
          - "None"

- Receive SMS (yes or no)
     + {receivesms}
          - "Yes"
          - "No"

Here is an example from when I was testing different codes:

![replacementcodes](https://c4265878.ssl.cf2.rackcdn.com/gsbcfamily.1512011533.emailReplacementCodes.png)


