### PR TITLE
Pull CCs from db rather than from EmailController closure #87

### DIFF
--- a/CmsData/Email/Emailer.cs
+++ b/CmsData/Email/Emailer.cs
@@ -465,7 +465,7 @@ namespace CmsData
             return aa;
         }
 
-        public void SendPeopleEmail(int queueid, List<MailAddress> cc = null)
+        public void SendPeopleEmail(int queueid)
         {
             var emailqueue = EmailQueues.Single(ee => ee.Id == queueid);
             var sysFromEmail = Util.SysFromEmail;
@@ -483,6 +483,12 @@ namespace CmsData
             var m = new EmailReplacements(this, body, from);
             emailqueue.Started = DateTime.Now;
             SubmitChanges();
+
+            List<MailAddress> cc = new List<MailAddress>();
+            if (emailqueue.CClist != null)
+            {
+                cc = emailqueue.CClist.Split(',').Select(addr => new MailAddress(addr)).ToList();
+            }
 
             if (emailqueue.SendFromOrgId.HasValue)
             {
@@ -552,7 +558,7 @@ namespace CmsData
             }
 
             // Handle CC MailAddresses.  These do not get DoReplacement support.
-            if (cc != null)
+            if (cc.Count > 0)
             {
                 foreach (var ma in cc)
                 {
@@ -591,7 +597,7 @@ namespace CmsData
             else if (emailqueue.Transactional == false)
             {
                 var nitems = emailqueue.EmailQueueTos.Count();
-                if (cc != null) { nitems += cc.Count(); }
+                if (cc.Count > 0) { nitems += cc.Count; }
                 if (nitems > 1)
                     NotifySentEmails(from.Address, from.DisplayName,
                         emailqueue.Subject, nitems, emailqueue.Id);

--- a/CmsWeb/Areas/Main/Controllers/EmailController.cs
+++ b/CmsWeb/Areas/Main/Controllers/EmailController.cs
@@ -250,7 +250,7 @@ namespace CmsWeb.Areas.Main.Controllers
                     // set these again inside thread local storage
                     Util.UserEmail = userEmail;
                     Util.IsInRoleEmailTest = isInRoleEmailTest;
-                    db.SendPeopleEmail(id, m.CcAddresses);
+                    db.SendPeopleEmail(id);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes #87.  Since scheduled emails run in a different process than the web app we should be pulling the CC list from the database rather than a closure.