### PR TITLE
Allow dash in settings names

### DIFF
--- a/CmsWeb/Areas/Setup/Controllers/SettingController.cs
+++ b/CmsWeb/Areas/Setup/Controllers/SettingController.cs
@@ -21,7 +21,7 @@ namespace CmsWeb.Areas.Setup.Controllers
         [HttpPost]
         public ActionResult Create(string id)
         {
-            if(!Regex.IsMatch(id, @"\A[A-z0-9]*\z"))
+            if (!Regex.IsMatch(id, @"\A[A-z0-9-]*\z"))
                 return Message("Invalid characters in setting id");
 
             if (!DbUtil.Db.Settings.Any(s => s.Id == id))


### PR DESCRIPTION
The [documentation specifies settings](http://docs.touchpointsoftware.com/Administration/CustomHeader.html) such as `UX-HeaderLogo` but the prior regex wouldn't allow for dashes. This should fix that.