### PR TITLE
Support custom shells on the login page

### DIFF
--- a/CmsWeb/Areas/Manage/Controllers/AccountController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/AccountController.cs
@@ -480,9 +480,11 @@ namespace CmsWeb.Areas.Manage.Controllers
             {
                 var re = new Regex(@"(.*<!--FORM START-->\s*).*(<!--FORM END-->.*)", RegexOptions.Singleline);
                 var t = re.Match(shell).Groups[1].Value.Replace("<!--FORM CSS-->", ViewExtensions2.Bootstrap3Css());
+                t = t.Replace("<html>\r\n<head>\r\n\t<title></title>\r\n</head>\r\n<body>&nbsp;</body>\r\n", "");
                 ViewBag.hasshell = true;
                 ViewBag.top = t;
                 var b = re.Match(shell).Groups[2].Value;
+                b = b.Replace("</html>", "");
                 ViewBag.bottom = b;
             }
             else

--- a/CmsWeb/Areas/Manage/Controllers/AccountController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/AccountController.cs
@@ -126,6 +126,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [Route("~/Error")]
         public ActionResult Error(string e)
         {
+            TryLoadAlternateShell();
             ViewBag.Message = e;
             return View();
         }
@@ -378,6 +379,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         {
             if (!id.HasValue)
                 return Content("invalid URL");
+            TryLoadAlternateShell();
             var user = DbUtil.Db.Users.SingleOrDefault(u => u.ResetPasswordCode == id);
             if (user == null || (user.ResetPasswordExpires.HasValue && user.ResetPasswordExpires < DateTime.Now))
                 return View("LinkUsed");

--- a/CmsWeb/Areas/Manage/Controllers/AccountController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/AccountController.cs
@@ -135,6 +135,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [MyRequireHttps]
         public ActionResult LogOn(string returnUrl)
         {
+            TryLoadAlternateShell();
             var r = DbUtil.CheckDatabaseExists(Util.CmsHost);
             var redirect = ViewExtensions2.DatabaseErrorUrl(r);
             if (redirect != null)
@@ -149,8 +150,6 @@ namespace CmsWeb.Areas.Manage.Controllers
                     return Redirect(returnUrl);
                 return Redirect("/");
             }
-
-            TryLoadAlternateShell();
 
             var m = new AccountInfo {ReturnUrl = returnUrl};
             return View(m);
@@ -182,6 +181,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [HttpPost, MyRequireHttps]
         public ActionResult LogOn(AccountInfo m)
         {
+            TryLoadAlternateShell();
             if (m.ReturnUrl.HasValue())
             {
                 var lc = m.ReturnUrl.ToLower();
@@ -191,7 +191,7 @@ namespace CmsWeb.Areas.Manage.Controllers
 
             if (!m.UsernameOrEmail.HasValue())
                 return View(m);
-
+            
             var ret = AccountModel.AuthenticateLogon(m.UsernameOrEmail, m.Password, Session, Request);
             if (ret is string)
             {
@@ -237,6 +237,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [MyRequireHttps]
         public ActionResult ForgotUsername(string email)
         {
+            TryLoadAlternateShell();
             if (Request.HttpMethod.ToUpper() == "GET")
                 return View();
 
@@ -266,8 +267,6 @@ namespace CmsWeb.Areas.Manage.Controllers
                     CMSRoleProvider.provider.GetAdmins(),
                     $"touchpoint unknown email: {email} forgot username", "no content");
 
-            TryLoadAlternateShell();
-
             return RedirectToAction("RequestUsername");
         }
 
@@ -275,7 +274,6 @@ namespace CmsWeb.Areas.Manage.Controllers
         public ActionResult ForgotPassword()
         {
             TryLoadAlternateShell();
-
             var m = new AccountInfo();
             return View(m);
         }
@@ -283,6 +281,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [HttpPost, MyRequireHttps]
         public ActionResult ForgotPassword(AccountInfo m)
         {
+            TryLoadAlternateShell();
             if (!ModelState.IsValid)
                 return View(m);
             AccountModel.ForgotPassword(m.UsernameOrEmail);
@@ -293,6 +292,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [MyRequireHttps]
         public ActionResult CreateAccount(string id)
         {
+            TryLoadAlternateShell();
             if (!id.HasValue())
                 return Content("invalid URL");
 
@@ -331,8 +331,6 @@ namespace CmsWeb.Areas.Manage.Controllers
             ViewBag.RequireOneNumber = MembershipService.RequireOneNumber;
             ViewBag.RequireOneUpper = MembershipService.RequireOneUpper;
             
-            TryLoadAlternateShell();
-
             return View("SetPassword");
         }
 
@@ -340,7 +338,6 @@ namespace CmsWeb.Areas.Manage.Controllers
         public ActionResult RequestPassword()
         {
             TryLoadAlternateShell();
-
             return View();
         }
 
@@ -348,7 +345,6 @@ namespace CmsWeb.Areas.Manage.Controllers
         public ActionResult RequestUsername()
         {
             TryLoadAlternateShell();
-
             return View();
         }
 
@@ -356,11 +352,11 @@ namespace CmsWeb.Areas.Manage.Controllers
         [Authorize]
         public ActionResult ChangePassword()
         {
+            TryLoadAlternateShell();
             ViewBag.MinPasswordLength = MembershipService.MinPasswordLength;
             ViewBag.RequireSpecialCharacter = MembershipService.RequireSpecialCharacter;
             ViewBag.RequireOneNumber = MembershipService.RequireOneNumber;
             ViewBag.RequireOneUpper = MembershipService.RequireOneUpper;
-            TryLoadAlternateShell();
             return View();
         }
 
@@ -377,9 +373,10 @@ namespace CmsWeb.Areas.Manage.Controllers
         [HttpPost]
         public ActionResult SetPasswordConfirm(Guid? id)
         {
+            TryLoadAlternateShell();
             if (!id.HasValue)
                 return Content("invalid URL");
-            TryLoadAlternateShell();
+
             var user = DbUtil.Db.Users.SingleOrDefault(u => u.ResetPasswordCode == id);
             if (user == null || (user.ResetPasswordExpires.HasValue && user.ResetPasswordExpires < DateTime.Now))
                 return View("LinkUsed");
@@ -402,6 +399,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [Authorize]
         public ActionResult SetPassword(string newPassword, string confirmPassword)
         {
+            TryLoadAlternateShell();
             ViewBag.user = User.Identity.Name;
             ViewBag.MinPasswordLength = MembershipService.MinPasswordLength;
             ViewBag.RequireSpecialCharacter = MembershipService.RequireSpecialCharacter;
@@ -430,6 +428,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [HttpPost]
         public ActionResult ChangePassword(string currentPassword, string newPassword, string confirmPassword)
         {
+            TryLoadAlternateShell();
             ViewBag.user = User.Identity.Name;
             ViewBag.MinPasswordLength = MembershipService.MinPasswordLength;
             ViewBag.RequireSpecialCharacter = MembershipService.RequireSpecialCharacter;
@@ -456,6 +455,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [MyRequireHttps]
         public ActionResult ChangePasswordSuccess()
         {
+            TryLoadAlternateShell();
             var rd = DbUtil.Db.Setting("RedirectAfterPasswordChange", "");
             if (rd.HasValue())
                 return Redirect(rd);
@@ -479,7 +479,7 @@ namespace CmsWeb.Areas.Manage.Controllers
             if (shell.HasValue())
             {
                 var re = new Regex(@"(.*<!--FORM START-->\s*).*(<!--FORM END-->.*)", RegexOptions.Singleline);
-                var t = re.Match(shell).Groups[1].Value;
+                var t = re.Match(shell).Groups[1].Value.Replace("<!--FORM CSS-->", ViewExtensions2.Bootstrap3Css());
                 ViewBag.hasshell = true;
                 ViewBag.top = t;
                 var b = re.Match(shell).Groups[2].Value;
@@ -510,7 +510,6 @@ namespace CmsWeb.Areas.Manage.Controllers
         {
             [Required]
             public string UsernameOrEmail { get; set; }
-
             public string Password { get; set; }
             public string ReturnUrl { get; set; }
         }

--- a/CmsWeb/Areas/Manage/Views/Account/ChangePassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ChangePassword.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/ChangePassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ChangePassword.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Change Password";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Change Password</h1>
 @Html.ValidationSummaryBootstrap(true)

--- a/CmsWeb/Areas/Manage/Views/Account/ChangePasswordSuccess.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ChangePasswordSuccess.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Change Password";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Change Password</h1>
 <div class="alert alert-success" role="alert">

--- a/CmsWeb/Areas/Manage/Views/Account/ChangePasswordSuccess.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ChangePasswordSuccess.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/ForgotPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ForgotPassword.cshtml
@@ -4,7 +4,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/ForgotPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ForgotPassword.cshtml
@@ -1,7 +1,15 @@
 ﻿@model CmsWeb.Areas.Manage.Controllers.AccountController.AccountInfo
 @{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Forgot Password/Create Account";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Request Password</h1>
 <div class="alert alert-warning alert-dismissible" role="alert">

--- a/CmsWeb/Areas/Manage/Views/Account/ForgotUsername.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ForgotUsername.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/ForgotUsername.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ForgotUsername.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Forgot Username";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Forgot Username</h1>
 @Html.ValidationSummaryBootstrap(true)

--- a/CmsWeb/Areas/Manage/Views/Account/LinkUsed.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/LinkUsed.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/LinkUsed.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/LinkUsed.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-Layout = "_Layout.cshtml";
-ViewBag.Title = "Password Link Expired";
+    ViewBag.Title = "Password Link Expired";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Set Password</h1>
 <div class="alert alert-danger" role="alert">

--- a/CmsWeb/Areas/Manage/Views/Account/LogOn.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/LogOn.cshtml
@@ -6,15 +6,20 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {
         Layout = "_Layout.cshtml";
     }
 }
-
-<h1 class="form-header">@ViewExtensions2.DbSetting("NameOfChurch", "Name Of Church: " + Util.Host)</h1>
+@if ((bool?) ViewBag.hasshell == true)
+{
+    <div class="no-header"></div>
+}
+else {
+    <h1 class="form-header">@ViewExtensions2.DbSetting("NameOfChurch", "Name Of Church: " + Util.Host)</h1>
+}
 @if (DbUtil.LoginNotice().HasValue())
 {
     <div class="col-sm-12">

--- a/CmsWeb/Areas/Manage/Views/Account/LogOn.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/LogOn.cshtml
@@ -2,9 +2,18 @@
 @using UtilityExtensions
 @model CmsWeb.Areas.Manage.Controllers.AccountController.AccountInfo
 @{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Logon to TouchPoint";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
+
 <h1 class="form-header">@ViewExtensions2.DbSetting("NameOfChurch", "Name Of Church: " + Util.Host)</h1>
 @if (DbUtil.LoginNotice().HasValue())
 {
@@ -45,4 +54,5 @@
             $redirect.val($redirect.val() + window.location.hash);
         });
     </script>
+
 }

--- a/CmsWeb/Areas/Manage/Views/Account/RequestPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/RequestPassword.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/RequestPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/RequestPassword.cshtml
@@ -1,7 +1,16 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Password Sent";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
+
 <h1 class="form-header">Password Request</h1>
 <div class="alert alert-success" role="alert">
     <strong>Password Sent</strong> If you provided the username or email address associated with your record, you should receive an email shortly with a link to reset your password. Please contact the church if you do not receive it.

--- a/CmsWeb/Areas/Manage/Views/Account/RequestUsername.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/RequestUsername.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/RequestUsername.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/RequestUsername.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = " Sent";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Username Request</h1>
 <div class="alert alert-success" role="alert">

--- a/CmsWeb/Areas/Manage/Views/Account/ResetPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ResetPassword.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/ResetPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/ResetPassword.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-Layout = "~/Views/Shared/Site3.cshtml";
-ViewBag.Title = "ResetPassword";
+    ViewBag.Title = "ResetPassword";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "~/Views/Shared/Site3.cshtml";
+    }
 }
 <h2>Change Password</h2>
 <p>

--- a/CmsWeb/Areas/Manage/Views/Account/SetPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/SetPassword.cshtml
@@ -3,7 +3,7 @@
 
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/SetPassword.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/SetPassword.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Set Password";
+
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <h1 class="form-header">Set Your Password</h1>
 @Html.ValidationSummaryBootstrap(true)

--- a/CmsWeb/Areas/Manage/Views/Account/SetPasswordConfirm.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/SetPasswordConfirm.cshtml
@@ -1,6 +1,14 @@
 ﻿@{
-    Layout = "_Layout.cshtml";
     ViewBag.Title = "Confirm Password Reset";
+    
+    if ((bool?)ViewData["hasshell"] == true)
+    {
+        Layout = "_CustomLayout.cshtml";
+    }
+    else
+    {
+        Layout = "_Layout.cshtml";
+    }
 }
 <br/>
 @using (Html.BeginForm("SetPasswordConfirm", "Account"))

--- a/CmsWeb/Areas/Manage/Views/Account/SetPasswordConfirm.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/SetPasswordConfirm.cshtml
@@ -3,7 +3,7 @@
     
     if ((bool?)ViewData["hasshell"] == true)
     {
-        Layout = "_CustomLayout.cshtml";
+        Layout = "_ShellLayout.cshtml";
     }
     else
     {

--- a/CmsWeb/Areas/Manage/Views/Account/_CustomLayout.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/_CustomLayout.cshtml
@@ -1,4 +1,0 @@
-﻿@Html.Raw((string)ViewData["top"])
-@RenderBody()
-@Html.Raw((string)ViewData["bottom"])
-@RenderSection("scripts", false)

--- a/CmsWeb/Areas/Manage/Views/Account/_CustomLayout.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/_CustomLayout.cshtml
@@ -1,0 +1,4 @@
+﻿@Html.Raw((string)ViewData["top"])
+@RenderBody()
+@Html.Raw((string)ViewData["bottom"])
+@RenderSection("scripts", false)

--- a/CmsWeb/Areas/Manage/Views/Account/_ShellLayout.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/_ShellLayout.cshtml
@@ -1,93 +1,94 @@
-﻿@Html.Action("Index", "MobileAppMenu", new { area = "" })
-@Html.Raw((string)ViewBag.top)
-<style>
-    input[type="text"] {
-        text-transform: lowercase;
-    }
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="shortcut icon" href="@Url.Content("~/favicon.ico?v=2")">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, maximum-scale=1.0">
+    <title>@ViewBag.Title</title>
+</head>
+<body>
+    @Html.Action("Index", "MobileAppMenu", new { area = "" })
+    @Html.Raw((string)ViewBag.top)
+    <style>
+        input[type="text"] {
+            text-transform: lowercase;
+        }
+        .account {
+            text-align: center;
+        }
+        .account .form-header {
+            font-size: 25px;
+            font-weight: 300;
+            text-align: center;
+            margin: 40px 0;
+        }
+        .account .no-header {
+            margin-bottom: 40px;
+        }
+        .account .bordered, .account .panel, .account .table, .account hr {
+            border-color: #e2e2e2;
+        }
+        .account .panel {
+            max-width: 360px;
+            margin: 0 auto;
+            padding: 27px;
+        }
+        .panel, .panel-default {
+            border-color: #e4e4e4;
+            margin-bottom: 22px;
+            position: relative;
+            -webkit-box-shadow: none;
+            box-shadow: none;
+        }
+        .account .signin-password {
+            position: relative;
+        }
+        .account .signin-password input {
+            padding-right: 70px;
+        }
+        .account .signin-password .forgot {
+            position: absolute;
+            right: 10px;
+            top: 10px;
+            color: #555;
+            background: #f1f1f1;
+            border-radius: 2px;
+            line-height: 25px;
+            padding: 0 7px;
+            font-size: 12px;
+        }
+        .account .signin-with {
+            max-width: 360px;
+            padding: 20px;
+            margin: 0 auto;
+            text-align: center;
+        }
+        .account .signin-with .header {
+            font-size: 16px;
+            font-weight: 300;
+            text-align: center;
+            margin: 0 0 20px;
+        }
+        .account .signin-with .header a {
+            text-decoration: underline;
+        }
+        .account .alert {
+            width: 360px;
+            margin: auto;
+            margin-bottom: 20px;
+            text-align: left !important;
+        }
+    </style>
+    @RenderSection("head", false)
+    <div class="account">
+        @RenderBody()
+    </div>
+    @Html.Raw((string)ViewBag.bottom)
+    @ViewExtensions2.jQuery()
+    @RenderSection("scripts", false)
+</body>
+</html>
 
-    .account {
-        text-align: center;
-    }
 
-    .account .form-header {
-        font-size: 25px;
-        font-weight: 300;
-        text-align: center;
-        margin: 40px 0;
-    }
 
-    .account .no-header {
-        margin-bottom: 40px;
-    }
-
-    .account .bordered, .account .panel, .account .table, .account hr {
-        border-color: #e2e2e2;
-    }
-
-    .account .panel {
-        max-width: 360px;
-        margin: 0 auto;
-        padding: 27px;
-    }
-
-    .panel, .panel-default {
-        border-color: #e4e4e4;
-        margin-bottom: 22px;
-        position: relative;
-        -webkit-box-shadow: none;
-        box-shadow: none;
-    }
-
-    .account .signin-password {
-        position: relative;
-    }
-
-    .account .signin-password input {
-        padding-right: 70px;
-    }
-
-    .account .signin-password .forgot {
-        position: absolute;
-        right: 10px;
-        top: 10px;
-        color: #555;
-        background: #f1f1f1;
-        border-radius: 2px;
-        line-height: 25px;
-        padding: 0 7px;
-        font-size: 12px;
-    }
-
-    .account .signin-with {
-        max-width: 360px;
-        padding: 20px;
-        margin: 0 auto;
-        text-align: center;
-    }
-
-    .account .signin-with .header {
-        font-size: 16px;
-        font-weight: 300;
-        text-align: center;
-        margin: 0 0 20px;
-    }
-
-    .account .signin-with .header a {
-        text-decoration: underline;
-    }
-
-    .account .alert {
-        width: 360px;
-        margin: auto;
-        margin-bottom: 20px;
-        text-align: left !important;
-    }
-
-</style>
-@RenderSection("head", false)
-<div class="account">
-    @RenderBody()
-</div>
-@Html.Raw((string)ViewBag.bottom)
-@ViewExtensions2.jQuery()
-@RenderSection("scripts", false)

--- a/CmsWeb/Areas/Manage/Views/Account/_ShellLayout.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Account/_ShellLayout.cshtml
@@ -1,0 +1,93 @@
+﻿@Html.Action("Index", "MobileAppMenu", new { area = "" })
+@Html.Raw((string)ViewBag.top)
+<style>
+    input[type="text"] {
+        text-transform: lowercase;
+    }
+
+    .account {
+        text-align: center;
+    }
+
+    .account .form-header {
+        font-size: 25px;
+        font-weight: 300;
+        text-align: center;
+        margin: 40px 0;
+    }
+
+    .account .no-header {
+        margin-bottom: 40px;
+    }
+
+    .account .bordered, .account .panel, .account .table, .account hr {
+        border-color: #e2e2e2;
+    }
+
+    .account .panel {
+        max-width: 360px;
+        margin: 0 auto;
+        padding: 27px;
+    }
+
+    .panel, .panel-default {
+        border-color: #e4e4e4;
+        margin-bottom: 22px;
+        position: relative;
+        -webkit-box-shadow: none;
+        box-shadow: none;
+    }
+
+    .account .signin-password {
+        position: relative;
+    }
+
+    .account .signin-password input {
+        padding-right: 70px;
+    }
+
+    .account .signin-password .forgot {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        color: #555;
+        background: #f1f1f1;
+        border-radius: 2px;
+        line-height: 25px;
+        padding: 0 7px;
+        font-size: 12px;
+    }
+
+    .account .signin-with {
+        max-width: 360px;
+        padding: 20px;
+        margin: 0 auto;
+        text-align: center;
+    }
+
+    .account .signin-with .header {
+        font-size: 16px;
+        font-weight: 300;
+        text-align: center;
+        margin: 0 0 20px;
+    }
+
+    .account .signin-with .header a {
+        text-decoration: underline;
+    }
+
+    .account .alert {
+        width: 360px;
+        margin: auto;
+        margin-bottom: 20px;
+        text-align: left !important;
+    }
+
+</style>
+@RenderSection("head", false)
+<div class="account">
+    @RenderBody()
+</div>
+@Html.Raw((string)ViewBag.bottom)
+@ViewExtensions2.jQuery()
+@RenderSection("scripts", false)

--- a/CmsWeb/CmsWeb.csproj
+++ b/CmsWeb/CmsWeb.csproj
@@ -2346,6 +2346,7 @@
     <Content Include="Views\Home\Test.cshtml" />
     <Content Include="Views\Shared\Toolbar\Custom.cshtml" />
     <Content Include="Views\Shared\PageMessage.cshtml" />
+    <Content Include="Areas\Manage\Views\Account\_CustomLayout.cshtml" />
     <None Include="Web.Impersonate.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/CmsWeb/CmsWeb.csproj
+++ b/CmsWeb/CmsWeb.csproj
@@ -2346,7 +2346,7 @@
     <Content Include="Views\Home\Test.cshtml" />
     <Content Include="Views\Shared\Toolbar\Custom.cshtml" />
     <Content Include="Views\Shared\PageMessage.cshtml" />
-    <Content Include="Areas\Manage\Views\Account\_CustomLayout.cshtml" />
+    <Content Include="Areas\Manage\Views\Account\_ShellLayout.cshtml" />
     <None Include="Web.Impersonate.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/CmsWeb/Properties/PublishProfiles/work.pubxml
+++ b/CmsWeb/Properties/PublishProfiles/work.pubxml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <publishUrl>Build\Deploy\work</publishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <ExcludeApp_Data>True</ExcludeApp_Data>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <PrecompileBeforePublish>True</PrecompileBeforePublish>
+    <EnableUpdateable>False</EnableUpdateable>
+    <DebugSymbols>False</DebugSymbols>
+    <WDPMergeOption>MergeEachIndividualFolder</WDPMergeOption>
+    <UseMerge>True</UseMerge>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This pull request implements the feature so that the login page (and related views) can be displayed with a custom shell.

If the user sets an admin setting named `UX-LoginPageShell` whose value is the name of HTML special content for a shell, then that shell will be used on the login page.