### PR TITLE
Fix bug: Creating or Renaming a Sub-group by pressing Enter...

### DIFF
--- a/CmsWeb/Areas/Org/Views/OrgGroups/Index.cshtml
+++ b/CmsWeb/Areas/Org/Views/OrgGroups/Index.cshtml
@@ -46,7 +46,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <input type="button" value="Cancel" class="btn btn-default" data-dismiss="modal" />
-                                    <a href="#" class="btn btn-primary" id="submit-new-group">Submit</a>
+                                    <input type="submit" class="btn btn-primary" value="Submit" />
                                 </div>
                             </form>
                         </div>
@@ -70,7 +70,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <input type="button" value="Cancel" class="btn btn-default" data-dismiss="modal" />
-                                    <a href="#" class="btn btn-primary" id="submit-rename-group">Submit</a>
+                                    <input type="submit" class="btn btn-primary" value="Submit" />
                                 </div>
                             </form>
                         </div>

--- a/CmsWeb/Content/touchpoint/js/org/org-groups.js
+++ b/CmsWeb/Content/touchpoint/js/org/org-groups.js
@@ -263,9 +263,9 @@
         $("input.new-group-name").val("").focus();
     });
 
-    $("body").on('click', '#submit-new-group', function (ev) {
+    $("#new-group-modal form").submit(function (ev) {
         ev.preventDefault();
-        var f = $(this).closest('form');
+        var f = $(this);
         var q = f.serialize();
         var url = f.attr('action');
         $.post(url, q, function (ret) {
@@ -283,12 +283,16 @@
 
         $("input.rename-group-id").val(groupId);
         $("input.rename-group-name").val(groupName);
-        $('#rename-group-modal').modal('show');
+        $('#rename-group-modal').modal('show');        
     });
     
-    $("body").on('click', '#submit-rename-group', function (ev) {
+    $('#rename-group-modal').on('shown.bs.modal', function (e) {
+        $('input.rename-group-name').focus();
+    });
+    
+    $("#rename-group-modal form").submit(function (ev) {
         ev.preventDefault();
-        var f = $(this).closest('form');
+        var f = $(this);
         var q = f.serialize();
         var url = f.attr('action');
         $.post(url, q, function (ret) {


### PR DESCRIPTION
…does not post correctly (uses regular POST instead of jquery ajax post)
Also this PR enables input box to receive focus when the renaming sub-group modal opens.

The code change is simply using the jquery form "submit" event instead of button click event, so it catches the form whether it is submitted by clicking button, or submitted by hitting enter key while an input in the form is active.

