### PR TITLE
Minor bug fixes for Redeemer

### DIFF
--- a/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
@@ -52,9 +52,10 @@
                     }
                     <li><a href="/RepairTransactions/@oid" class="longrunop"><span class="org-context">Repair Transactions</span></a></li>
                 } @*@if (User.IsInRole("ministrEspace"))
-                    {
-                        <li><a id="addMESEvent" href="#" orgid="@oid"><span class="org-context">Add ministrEspace Event</span></a></li>
-                    }*@</ul>
+                {
+                    <li><a id="addMESEvent" href="#" orgid="@oid"><span class="org-context">Add ministrEspace Event</span></a></li>
+                }*@
+            </ul>
         </li>
         <li class="col-sm-6">
             @Html.Partial("Toolbar/GearStandard")
@@ -68,6 +69,10 @@ else
             <ul>
                 <li class="dropdown-header">Content</li>
                 <li><a href="/OrgContent/@o.OrganizationId" class="qid">Members Only Page</a></li>
+                @if (model.IsVolunteerLeader && o.RegistrationTypeId == RegistrationTypeCode.ChooseVolunteerTimes)
+                {
+                    <li><a id="VolunteerCalendar" href="/Volunteers/Calendar/@oid" target="calendar"><span class="org-context">Volunteer Calendar</span></a></li>
+                }
             </ul>
         </li>
     </ul>

--- a/CmsWeb/CmsWeb.csproj
+++ b/CmsWeb/CmsWeb.csproj
@@ -132,9 +132,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="EPPlus, Version=4.0.4.0, Culture=neutral">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EPPlus.4.0.4\lib\net20\EPPlus.dll</HintPath>
+    <Reference Include="EPPlus, Version=4.1.0.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
+      <HintPath>..\packages\EPPlus.4.1.0\lib\net40\EPPlus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Handlebars, Version=1.0.0.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
       <HintPath>..\packages\Handlebars.Net.1.4.4\lib\Handlebars.dll</HintPath>

--- a/CmsWeb/Views/ExtraValue/NewStandard.cshtml
+++ b/CmsWeb/Views/ExtraValue/NewStandard.cshtml
@@ -30,7 +30,7 @@
                 <div class="form-group">
                     <label for="EditableRolesList" class="control-label">Editable by Roles</label>
                     <div class="controls">
-                        @Html.DropDownList("EditableRolesList", new SelectList(Model.EditableRolesList, "Value", "Text"), new { multiple = "multiple", @class = "form-control multi-select" })
+                        @Html.DropDownList("EditableRolesList", new SelectList(Model.EditableSelectedRoles(), "Value", "Text"), new { multiple = "multiple", @class = "form-control multi-select" })
                     </div>
                 </div>
             }

--- a/CmsWeb/packages.config
+++ b/CmsWeb/packages.config
@@ -10,6 +10,7 @@
   <package id="DocX" version="1.0.0.13" targetFramework="net45" />
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
+  <package id="EPPlus" version="4.1.0" targetFramework="net46" />
   <package id="Handlebars.Net" version="1.4.4" targetFramework="net46" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net46" />
   <package id="iTextSharp" version="5.5.0" targetFramework="net45" />


### PR DESCRIPTION
This pull request includes the following:

* Use Nuget for EPPlus instead of a direct assembly reference - it resolved a minor compilation issue where CmsWeb and CmsData were using different versions of EPPlus
* Add Volunteer Calendar link for Org Leaders Only when their toolbar view is limited (as in Redeemer's case)
* Fix null reference issue related to the Add Extra Value dialog

Regarding the other issue that Karen reported related to OrgSearch, that was a data issue on staging that I resolved in the special content.