### PR TITLE
Ensure SGF handles various extra value types

### DIFF
--- a/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
+++ b/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
@@ -229,10 +229,16 @@ namespace CmsWeb.Areas.Public.Models
                          where e.Organization.DivOrgs.Any(ee => _divList.Contains(ee.DivId)) || orgTypes.Contains(e.Organization.OrganizationType.Description)
                          where e.Field == f.name
                          orderby e.Data
-                         select new FilterItem
-                          {
-                              value = e.Data
-                          }).DistinctBy(n => n.value).ToList();
+                         select e)
+                         .ToList()
+                         .Select(x => new FilterItem
+                         {
+                             value = x.Data ??
+                                     x.StrValue ??
+                                     x.DateValue?.ToString() ??
+                                     x.IntValue?.ToString() ??
+                                     x.BitValue?.ToString()
+                         }).DistinctBy(n => n.value).ToList();
                 }
 
 				i.Insert(0, new FilterItem { value = SHOW_ALL });


### PR DESCRIPTION
We inadvertently were only supporting text extra value types in the Small Group Finder! This should fix that - it just coalesces between whichever value is set which is easier in this case as the front end just needs string values.