### PR TITLE
SGF fixes related to extra values with spaces

### DIFF
--- a/CmsWeb/Areas/Org/Views/Org/CommunityGroup/CommunityGroup.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/CommunityGroup/CommunityGroup.cshtml
@@ -52,10 +52,15 @@
 </form>
     @helper ExtraDataFormAction(ExtraValueModel evmodel, bool xs = false)
     {
+        var canAddExtraValues = User.IsInRole("Admin") ||
+            (User.IsInRole("OrgLeadersOnly")
+            && DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs", false)
+            && !DbUtil.Db.Setting("UX-HideExtraValueEditForOrgLeaderOnly", false));
+
         if (xs)
         {
             <div class="visible-xs-block">
-                @if (User.IsInRole("Admin") || (User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs", false)))
+                @if (canAddExtraValues)
                 {
                     <a class="extravalue btn btn-success btn-block" href="/ExtraValue/NewStandard/@evmodel.Table/CommunityGroup/@evmodel.Id"><i class="fa fa-plus-circle"></i> Add Extra Value</a>
                     <a class="extravalue edit btn btn-default btn-block" href="/ExtraValue/ListStandard/@evmodel.Table/CommunityGroup/@evmodel.Id?title=Edit+Community+Group+Extra+Vaues"><i class="fa fa-pencil"></i> Edit Extra Value</a>
@@ -70,7 +75,7 @@
                 <div class="col-sm-12">
                     <div class="pull-right">
                         <a href="#" class="ajax-refresh btn btn-default"><i class="fa fa-refresh"></i> Refresh</a>
-                        @if (User.IsInRole("Admin") || (User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs", false)))
+                        @if (canAddExtraValues)
                         {
                             <a class="extravalue edit btn btn-default" href="/ExtraValue/ListStandard/@evmodel.Table/CommunityGroup/@evmodel.Id?title=Edit+Community+Group+Extra+Vaues"><i class="fa fa-pencil"></i> Edit Extra Value</a>
                             <a class="extravalue btn btn-success" href="/ExtraValue/NewStandard/@evmodel.Table/CommunityGroup/@evmodel.Id"><i class="fa fa-plus-circle"></i> Add Extra Value</a>

--- a/CmsWeb/Areas/People/Views/Person/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Index.cshtml
@@ -15,6 +15,11 @@
     {
         showResourcesTab = Model.PeopleId == Util.UserPeopleId || User.IsInRole("ViewResources");
     }
+    var showMinistryTab = User.IsInRole("Access");
+    if (!(User.IsInRole("OrgLeadersOnly") && !DbUtil.Db.Setting("UX-HideMinistryTabForOrgLeaders", false)))
+    {
+        showMinistryTab = false;
+    }
 }
 @section head
 {
@@ -206,53 +211,53 @@
     </div>
     <div id="profile-header">@Html.Partial("Personal/Header", Model)</div>
     <br/>
-    <ul class="nav nav-tabs" id="person-tabs">
-      <li class="active">
-        <a href="#personal" aria-controls="personal" data-toggle="tab">Personal</a>
-      </li>
-      <li id="involvementstop">
-        <a href="#enrollment" aria-controls="enrollment" data-toggle="tab">Involvement</a>
-      </li>
-      <li>
-        <a href="#profile" aria-controls="profile" data-toggle="tab">Profile</a>
-      </li>
-      @if (User.IsInRole("Access"))
-      {
-        <li>
-          <a href="#ministry" aria-controls="ministry" data-toggle="tab">Ministry</a>
-        </li>
-      }
-      @if (!User.IsInRole("Access") && Model.Person.CanUserSeeGiving)
-      {
-        <li id="givingstop">
-          <a href="#giving" aria-controls="giving" data-toggle="tab">Giving</a>
-        </li>
-      }
-      else if (Model.Person.CanUserSeeGiving)
-      {
-        <li>
-          <a href="#giving" aria-controls="giving" data-toggle="tab">Giving</a>
-        </li>
-      }
-      @if (Model.Person.CanUserSeeEmails)
-      {
-        <li>
-          <a href="#emails" aria-controls="emails" data-toggle="tab">Emails</a>
-        </li>
-      }
-      @if (showResourcesTab)
-      {
-        <li>
-            <a href="#resources" aria-controls="resources" data-toggle="tab">Resources</a>
-        </li>
-      }
-      @if (User.IsInRole("Edit") || User.IsInRole("Admin"))
-      {
-        <li>
-          <a href="#system" aria-controls="system" data-toggle="tab">System</a>
-        </li>
-      }
-    </ul>
+      <ul class="nav nav-tabs" id="person-tabs">
+          <li class="active">
+              <a href="#personal" aria-controls="personal" data-toggle="tab">Personal</a>
+          </li>
+          <li id="involvementstop">
+              <a href="#enrollment" aria-controls="enrollment" data-toggle="tab">Involvement</a>
+          </li>
+          <li>
+              <a href="#profile" aria-controls="profile" data-toggle="tab">Profile</a>
+          </li>
+          @if (showMinistryTab)
+          {
+              <li>
+                  <a href="#ministry" aria-controls="ministry" data-toggle="tab">Ministry</a>
+              </li>
+          }
+          @if (!User.IsInRole("Access") && Model.Person.CanUserSeeGiving)
+          {
+              <li id="givingstop">
+                  <a href="#giving" aria-controls="giving" data-toggle="tab">Giving</a>
+              </li>
+          }
+          else if (Model.Person.CanUserSeeGiving)
+          {
+              <li>
+                  <a href="#giving" aria-controls="giving" data-toggle="tab">Giving</a>
+              </li>
+          }
+          @if (Model.Person.CanUserSeeEmails)
+          {
+              <li>
+                  <a href="#emails" aria-controls="emails" data-toggle="tab">Emails</a>
+              </li>
+          }
+          @if (showResourcesTab)
+          {
+              <li>
+                  <a href="#resources" aria-controls="resources" data-toggle="tab">Resources</a>
+              </li>
+          }
+          @if (User.IsInRole("Edit") || User.IsInRole("Admin"))
+          {
+              <li>
+                  <a href="#system" aria-controls="system" data-toggle="tab">System</a>
+              </li>
+          }
+      </ul>
     <div class="tab-content">
       <div class="tab-pane fade in active" id="personal">
         @Html.Partial("Personal/Display", Model.basic)
@@ -281,7 +286,7 @@
           @Html.Partial("Emails/Tab", Model)
         </div>
       }
-      @if (DbUtil.Db.Setting("Resources-Enabled", false))
+      @if (resourcesEnabled)
       {
         <div class="tab-pane fade" id="resources">
             @Html.Partial("Resources/Tab", Model)

--- a/CmsWeb/Areas/Public/Controllers/OrgContentController.cs
+++ b/CmsWeb/Areas/Public/Controllers/OrgContentController.cs
@@ -34,6 +34,7 @@ namespace CmsWeb.Areas.Public
                     .Replace("{type}", org.OrganizationType?.Description ?? string.Empty)
                     .Replace("{division}", org.Division?.Name ?? string.Empty)
                     .Replace("{campus}", org.Campu?.Description ?? string.Empty)
+                    .Replace("{orgid}", org.OrganizationId.ToString())
                     .Replace("{name}", org.OrganizationName ?? string.Empty);
 
                 org.GetOrganizationExtras().ForEach(ev =>

--- a/CmsWeb/Areas/Public/Models/SGMapModel.cs
+++ b/CmsWeb/Areas/Public/Models/SGMapModel.cs
@@ -171,10 +171,16 @@ Meeting Time: [SGF:Day] at [SGF:Time]<br />
 
             foreach (var extra in org.OrganizationExtras)
             {
+                var val = extra.Data ??
+                          extra.StrValue ??
+                          extra.DateValue?.ToString() ??
+                          extra.IntValue?.ToString() ??
+                          extra.BitValue?.ToString();
+
                 if (extra.Field.StartsWith("SGF:"))
-                    values[extra.Field] = extra.Data;
+                    values[extra.Field] = val;
                 else if (loadAllValues)
-                    values[$"SGF:{extra.Field.Replace(" ", "")}"] = extra.Data;
+                    values[$"SGF:{extra.Field}"] = val;
             }
 
             return values;

--- a/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
+++ b/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
@@ -251,22 +251,20 @@ namespace CmsWeb.Areas.Public.Models
         {
             if (_search == null) return new List<Organization>();
 
-            var orgTypes = DbUtil.Db.Setting("SGF-OrgTypes", "").Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x));
+            var orgTypes = DbUtil.Db.Setting("SGF-OrgTypes", "").Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)).ToList();
 
             IQueryable<Organization> orgs;
             if (!orgTypes.Any())
             {
                 orgs = from o in DbUtil.Db.Organizations
-                           where o.DivOrgs.Any(ee => _divList.Contains(ee.DivId))
-                           //where o.OrganizationStatusId == CmsData.Codes.OrgStatusCode.Active
-                           select o;
+                       where o.DivOrgs.Any(ee => _divList.Contains(ee.DivId))
+                       select o;
             }
             else
             {
                 orgs = from o in DbUtil.Db.Organizations
-                           where orgTypes.Contains(o.OrganizationType.Description)
-                           //where o.OrganizationStatusId == CmsData.Codes.OrgStatusCode.Active
-                           select o;
+                       where orgTypes.Contains(o.OrganizationType.Description)
+                       select o;
             }
 
             foreach (var filter in _search)
@@ -276,8 +274,8 @@ namespace CmsWeb.Areas.Public.Models
                 if (filter.Key == "Campus")
                 {
                     orgs = from g in orgs
-                             where g.Campu.Description == filter.Value.values[0]
-                             select g;
+                           where g.Campu.Description == filter.Value.values[0]
+                           select g;
                 }
                 else if (filter.Key == "Time")
                 {

--- a/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
+++ b/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
@@ -13,33 +13,33 @@ using UtilityExtensions;
 
 namespace CmsWeb.Areas.Public.Models
 {
-	public class SmallGroupFinderModel
-	{
-		public const int TYPE_SETTING = 1;
-		public const int TYPE_FILTER = 2;
+    public class SmallGroupFinderModel
+    {
+        public const int TYPE_SETTING = 1;
+        public const int TYPE_FILTER = 2;
 
-		public const string SHOW_ALL = "-- All --";
+        public const string SHOW_ALL = "-- All --";
 
-		private SmallGroupFinder _sgf;
-		private Dictionary<string, SearchItem> _search;
-		private readonly List<int> _divList = new List<int>();
+        private SmallGroupFinder _sgf;
+        private Dictionary<string, SearchItem> _search;
+        private readonly List<int> _divList = new List<int>();
 
-	    private string _template;
-		private string _gutter;
-		private string _shell;
+        private string _template;
+        private string _gutter;
+        private string _shell;
         private readonly Controller _controller;
 
-	    public string Title
-	    {
-	        get
-	        {
-	            string title = null;
-	            if (_sgf != null)
-	                title = getSetting("Title")?.value;
+        public string Title
+        {
+            get
+            {
+                string title = null;
+                if (_sgf != null)
+                    title = getSetting("Title")?.value;
 
-	            return title ?? "Small Group Finder";
-	        }
-	    }
+                return title ?? "Small Group Finder";
+            }
+        }
 
         public bool UseShell { get; private set; }
 
@@ -50,129 +50,129 @@ namespace CmsWeb.Areas.Public.Models
         }
 
         public void load(string sName)
-		{
-			var xml = DbUtil.Content("SGF-" + sName + ".xml", "");
+        {
+            var xml = DbUtil.Content("SGF-" + sName + ".xml", "");
 
-			var xs = new XmlSerializer(typeof(SmallGroupFinder), new XmlRootAttribute("SGF"));
-			var sr = new StringReader(xml);
-			_sgf = (SmallGroupFinder)xs.Deserialize(sr);
+            var xs = new XmlSerializer(typeof(SmallGroupFinder), new XmlRootAttribute("SGF"));
+            var sr = new StringReader(xml);
+            _sgf = (SmallGroupFinder)xs.Deserialize(sr);
 
-			var divs = _sgf.divisionid?.Split(',') ?? new string [] {};
-			foreach (var div in divs)
-			{
-				_divList.Add(Convert.ToInt32(div));
-			}
+            var divs = _sgf.divisionid?.Split(',') ?? new string [] {};
+            foreach (var div in divs)
+            {
+                _divList.Add(Convert.ToInt32(div));
+            }
 
-			_shell = DbUtil.Content(_sgf.shell, "");
-			_template = DbUtil.Content(_sgf.layout, "");
-			_gutter = DbUtil.Content(_sgf.gutter, "");
-		}
+            _shell = DbUtil.Content(_sgf.shell, "");
+            _template = DbUtil.Content(_sgf.layout, "");
+            _gutter = DbUtil.Content(_sgf.gutter, "");
+        }
 
-		public bool hasShell()
-		{
-		    return !string.IsNullOrEmpty(_shell);
-		}
+        public bool hasShell()
+        {
+            return !string.IsNullOrEmpty(_shell);
+        }
 
-	    public string createFromShell()
-		{
-			_shell = _shell.Replace("[SGF:Gutter]", getGutter());
-			_shell = _shell.Replace("[SGF:Form]", getForm());
-			_shell = _shell.Replace("[SGF:Groups]", getGroupList());
+        public string createFromShell()
+        {
+            _shell = _shell.Replace("[SGF:Gutter]", getGutter());
+            _shell = _shell.Replace("[SGF:Form]", getForm());
+            _shell = _shell.Replace("[SGF:Groups]", getGroupList());
 
-			if (_search != null)
-			{
-				foreach (var entry in _search)
-				{
-					if (entry.Value.parse)
-					{
-						foreach (var value in entry.Value.values)
-						{
-							_shell = _shell.Replace("[" + entry.Key + ":" + value + "]", "checked=\"checked\"");
-						}
-					}
-					else
-					{
-						_shell = _shell.Replace("[" + entry.Key + ":" + entry.Value.values[0] + "]", "checked=\"checked\"");
-					}
-				}
+            if (_search != null)
+            {
+                foreach (var entry in _search)
+                {
+                    if (entry.Value.parse)
+                    {
+                        foreach (var value in entry.Value.values)
+                        {
+                            _shell = _shell.Replace("[" + entry.Key + ":" + value + "]", "checked=\"checked\"");
+                        }
+                    }
+                    else
+                    {
+                        _shell = _shell.Replace("[" + entry.Key + ":" + entry.Value.values[0] + "]", "checked=\"checked\"");
+                    }
+                }
 
-				_shell = Regex.Replace(_shell, GroupLookup.PATTERN_CLEAN_CHECKED, "");
-			}
+                _shell = Regex.Replace(_shell, GroupLookup.PATTERN_CLEAN_CHECKED, "");
+            }
 
-			return _shell;
-		}
+            return _shell;
+        }
 
-		public void setSearch(Dictionary<string, SearchItem> newSearch)
-		{
-			_search = newSearch;
-		}
+        public void setSearch(Dictionary<string, SearchItem> newSearch)
+        {
+            _search = newSearch;
+        }
 
-		public bool IsSelectedValue(string key, string value)
-		{
-			if (_search == null) return false;
+        public bool IsSelectedValue(string key, string value)
+        {
+            if (_search == null) return false;
 
-			if (_search.ContainsKey(key))
-			{
-				if (_search[key].values.Contains(value))
-					return true;
-				else
-					return false;
-			}
-			else
-				return false;
-		}
+            if (_search.ContainsKey(key))
+            {
+                if (_search[key].values.Contains(value))
+                    return true;
+                else
+                    return false;
+            }
+            else
+                return false;
+        }
 
-		public List<Division> getDivisions()
-		{
-			return (from e in DbUtil.Db.Divisions
-					  where _divList.Contains(e.Id)
-					  select e).ToList();
-		}
+        public List<Division> getDivisions()
+        {
+            return (from e in DbUtil.Db.Divisions
+                      where _divList.Contains(e.Id)
+                      select e).ToList();
+        }
 
-		public int getCount(int type)
-		{
-			if (_sgf == null) return 0;
+        public int getCount(int type)
+        {
+            if (_sgf == null) return 0;
 
-			switch (type)
-			{
-				case TYPE_SETTING:
-					{
-						return _sgf.SGFSettings.Count();
-					}
+            switch (type)
+            {
+                case TYPE_SETTING:
+                    {
+                        return _sgf.SGFSettings.Count();
+                    }
 
-				case TYPE_FILTER:
-					{
-						return _sgf.SGFFilters.Count();
-					}
+                case TYPE_FILTER:
+                    {
+                        return _sgf.SGFFilters.Count();
+                    }
 
-				default: return 0;
-			}
-		}
+                default: return 0;
+            }
+        }
 
-		public List<SGFSetting> getSettings()
-		{
-			return _sgf.SGFSettings;
-		}
+        public List<SGFSetting> getSettings()
+        {
+            return _sgf.SGFSettings;
+        }
 
-		public SGFSetting getSetting(int id)
-		{
-			return _sgf.SGFSettings[id];
-		}
+        public SGFSetting getSetting(int id)
+        {
+            return _sgf.SGFSettings[id];
+        }
 
-		public SGFSetting getSetting(string name)
-		{
-			return (from s in _sgf.SGFSettings where s.name == name select s).FirstOrDefault();
-		}
+        public SGFSetting getSetting(string name)
+        {
+            return (from s in _sgf.SGFSettings where s.name == name select s).FirstOrDefault();
+        }
 
-		public List<SGFFilter> getFilters()
-		{
-			return _sgf.SGFFilters;
-		}
+        public List<SGFFilter> getFilters()
+        {
+            return _sgf.SGFFilters;
+        }
 
-		public SGFFilter getFilter(int id)
-		{
-			return _sgf.SGFFilters[id];
-		}
+        public SGFFilter getFilter(int id)
+        {
+            return _sgf.SGFFilters[id];
+        }
 
         private static readonly List<string> weekdayList = new List<string>()
         {
@@ -185,26 +185,26 @@ namespace CmsWeb.Areas.Public.Models
             "Saturday"
         };
 
-		public List<FilterItem> getFilterItems(int id)
-		{
+        public List<FilterItem> getFilterItems(int id)
+        {
             var orgTypes = DbUtil.Db.Setting("SGF-OrgTypes", "").Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x));
 
             var f = getFilter(id);
-			var i = new List<FilterItem>();
+            var i = new List<FilterItem>();
 
-			if (f.locked)
-			{
-				i.Add(new FilterItem { value = f.lockedvalue });
-			}
-			else
-			{
-			    if (f.weekdays)
-			    {
-			        i.AddRange(weekdayList.Select(w => new FilterItem
-			        {
+            if (f.locked)
+            {
+                i.Add(new FilterItem { value = f.lockedvalue });
+            }
+            else
+            {
+                if (f.weekdays)
+                {
+                    i.AddRange(weekdayList.Select(w => new FilterItem
+                    {
                         value = w
-			        }));
-			    }
+                    }));
+                }
                 else if (f.timeofdayonly)
                 {
                     i.AddRange(new [] {"AM", "PM"}.Select(x => new FilterItem
@@ -215,13 +215,13 @@ namespace CmsWeb.Areas.Public.Models
                 else if (f.name == "Campus")
                 {
                     var campusExclusions = f.exclude?.Split(',') ?? new string [] {};
-			        i = (from campus in DbUtil.Db.Campus
+                    i = (from campus in DbUtil.Db.Campus
                          orderby campus.Description
                          where !campusExclusions.Contains(campus.Description)
-			            select new FilterItem
-			            {
-			                value = campus.Description
-			            }).ToList();
+                        select new FilterItem
+                        {
+                            value = campus.Description
+                        }).ToList();
                 }
                 else
                 {
@@ -241,86 +241,116 @@ namespace CmsWeb.Areas.Public.Models
                          }).DistinctBy(n => n.value).ToList();
                 }
 
-				i.Insert(0, new FilterItem { value = SHOW_ALL });
-			}
+                i.Insert(0, new FilterItem { value = SHOW_ALL });
+            }
 
-			return i;
-		}
+            return i;
+        }
 
-		public List<Organization> getGroups()
-		{
-			if (_search == null) return new List<Organization>();
+        public List<Organization> getGroups()
+        {
+            if (_search == null) return new List<Organization>();
 
-		    var orgTypes = DbUtil.Db.Setting("SGF-OrgTypes", "").Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x));
+            var orgTypes = DbUtil.Db.Setting("SGF-OrgTypes", "").Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x));
 
-		    IQueryable<Organization> orgs;
-		    if (!orgTypes.Any())
-		    {
+            IQueryable<Organization> orgs;
+            if (!orgTypes.Any())
+            {
                 orgs = from o in DbUtil.Db.Organizations
                            where o.DivOrgs.Any(ee => _divList.Contains(ee.DivId))
                            //where o.OrganizationStatusId == CmsData.Codes.OrgStatusCode.Active
                            select o;
             }
-		    else
-		    {
+            else
+            {
                 orgs = from o in DbUtil.Db.Organizations
                            where orgTypes.Contains(o.OrganizationType.Description)
                            //where o.OrganizationStatusId == CmsData.Codes.OrgStatusCode.Active
                            select o;
             }
 
-			foreach (var filter in _search)
-			{
-				if (filter.Value.values.Contains(SHOW_ALL)) continue;
+            foreach (var filter in _search)
+            {
+                if (filter.Value.values.Contains(SHOW_ALL)) continue;
 
-			    if (filter.Key == "Campus")
-			    {
-					orgs = from g in orgs
-							 where g.Campu.Description == filter.Value.values[0]
-							 select g;
-			    }
+                if (filter.Key == "Campus")
+                {
+                    orgs = from g in orgs
+                             where g.Campu.Description == filter.Value.values[0]
+                             select g;
+                }
                 else if (filter.Key == "Time")
                 {
-					orgs = from g in orgs
-							 where g.OrganizationExtras.SingleOrDefault(oe => oe.Field == "Time").Data.EndsWith(filter.Value.values[0])
-							 select g;
+                    var val = filter.Value.values[0];
+                    orgs = from g in orgs
+                           where g.OrganizationExtras
+                              .Any(oe => oe.Field == "Time" &&
+                                  (
+                                      oe.StrValue.ToLower().EndsWith(val) ||
+                                      oe.Data.ToLower().EndsWith(val) ||
+                                      oe.DateValue != null && oe.DateValue.ToString().EndsWith(val) ||
+                                      oe.IntValue != null && oe.IntValue.ToString().EndsWith(val) ||
+                                      oe.BitValue != null && oe.BitValue.ToString().EndsWith(val)
+                                  )
+                              )
+                           select g;
                 }
-				else if (filter.Value.parse)
-				{
-					orgs = from g in orgs
-							 where g.OrganizationExtras.Any(oe => oe.Field == filter.Key && filter.Value.values.Contains(oe.Data))
-							 select g;
-				}
-				else
-				{
-					orgs = from g in orgs
-							 where g.OrganizationExtras.Any(oe => oe.OrganizationId == g.OrganizationId && oe.Field == filter.Key && oe.Data == filter.Value.values[0])
-							 select g;
-				}
+                else if (filter.Value.parse)
+                {
+                    var vals = filter.Value.values;
+                    orgs = from g in orgs
+                           where g.OrganizationExtras
+                               .Any(oe => oe.Field == filter.Key &&
+                                   (
+                                      vals.Contains(oe.StrValue) ||
+                                      vals.Contains(oe.Data) ||
+                                      oe.DateValue != null && vals.Contains(oe.DateValue.ToString()) ||
+                                      oe.IntValue != null && vals.Contains(oe.IntValue.ToString()) ||
+                                      oe.BitValue != null && vals.Contains(oe.BitValue.ToString())
+                                   )
+                               )
+                           select g;
+                }
+                else
+                {
+                    var val = filter.Value.values[0];
+                    orgs = from g in orgs
+                           where g.OrganizationExtras
+                              .Any(oe => oe.OrganizationId == g.OrganizationId && oe.Field == filter.Key &&
+                                  (
+                                      oe.StrValue == val ||
+                                      oe.Data.ToLower() == val ||
+                                      oe.DateValue != null && oe.DateValue.ToString() == val ||
+                                      oe.IntValue != null && oe.IntValue.ToString() == val ||
+                                      oe.BitValue != null && oe.BitValue.ToString() == val
+                                  )
+                              )
+                           select g;
+                }
 
-			}
+            }
 
-			return orgs.OrderBy(gg => gg.OrganizationName).ToList<Organization>();
-		}
+            return orgs.OrderBy(gg => gg.OrganizationName).ToList();
+        }
 
-		public string replaceAndWrite(GroupLookup gl)
-		{
-			var temp = HttpUtility.HtmlDecode(string.Copy(_template));
+        public string replaceAndWrite(GroupLookup gl)
+        {
+            var temp = HttpUtility.HtmlDecode(string.Copy(_template));
 
-			foreach (var item in gl.values)
-			{
-				temp = temp.Replace("[" + item.Key + "]", item.Value);
-			}
+            foreach (var item in gl.values)
+            {
+                temp = temp.Replace("[" + item.Key + "]", item.Value);
+            }
 
-			temp = Regex.Replace(temp, GroupLookup.PATTERN_CLEAN, "");
+            temp = Regex.Replace(temp, GroupLookup.PATTERN_CLEAN, "");
 
-			return temp;
-		}
+            return temp;
+        }
 
-		public string getGutter()
-		{
-			return _gutter;
-		}
+        public string getGutter()
+        {
+            return _gutter;
+        }
 
         public string RenderViewToString(string viewName, object model)
         {
@@ -335,87 +365,93 @@ namespace CmsWeb.Areas.Public.Models
             }
         }
 
-		public string getForm()
-		{
-		    return RenderViewToString("MapForm", this);
-		}
+        public string getForm()
+        {
+            return RenderViewToString("MapForm", this);
+        }
 
-		public string getGroupList()
-		{
-			var sList = "";
+        public string getGroupList()
+        {
+            var sList = "";
 
-			foreach (var group in getGroups())
-			{
-				var gl = new GroupLookup();
-				gl.populateFromOrg(group);
-				sList += replaceAndWrite(gl);
-			}
-
-			return sList;
-		}
-	}
-
-	public class FilterItem
-	{
-		public string value;
-	}
-
-	public class GroupLookup
-	{
-		public const string PATTERN_CLEAN = @"\[SGF:\w*\]";
-		public const string PATTERN_CLEAN_CHECKED = @"\[SGF:\w*:\w*\]";
-		public static string[] DAY_LAST = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "", "", "", "Any" };
-
-		public Dictionary<string, string> values = new Dictionary<string, string>();
-
-		public void populateFromOrg(Organization org)
-		{
-			var leader = (from e in DbUtil.Db.People
-							  where e.PeopleId == org.LeaderId
-							  select e).SingleOrDefault();
-
-			values["SGF:OrgID"] = org.OrganizationId.ToString();
-			values["SGF:Name"] = org.OrganizationName;
-			values["SGF:Description"] = org.Description;
-			values["SGF:Room"] = org.Location;
-			values["SGF:Leader"] = org.LeaderName;
-			values["SGF:DateStamp"] = DateTime.Now.ToString("yyyy-MM-dd");
-			values["SGF:Schedule"] = "";
-			values["SGF:Campus"] = org.Campu?.Description;
-
-			if (leader != null && leader.PictureId != null)
-				values["SGF:LeaderPicSrc"] = "/Portrait/" + leader.Picture.SmallId.Value + "?v=" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
-			else
-				values["SGF:LeaderPicSrc"] = "/Portrait/-3";
-
-			if (org.OrgSchedules.Count > 0)
-			{
-				int count = 0;
-				foreach (var schedule in org.OrgSchedules)
-				{
-					if (count > 0) values["SGF:Schedule"] += "; ";
-					values["SGF:Schedule"] += DAY_LAST[schedule.SchedDay ?? 0] + ", " + schedule.SchedTime.ToString2("t"); ;
-					count++;
-				}
-			}
-
-		    var loadAllValues = DbUtil.Db.Setting("SGF-LoadAllExtraValues", false);
-
-			foreach (var extra in org.OrganizationExtras)
-			{
-				if (extra.Field.StartsWith("SGF:"))
-					values[extra.Field] = extra.Data;
-                else if(loadAllValues)
-                    values[$"SGF:{extra.Field.Replace(" ", "")}"] = extra.Data;
+            foreach (var group in getGroups())
+            {
+                var gl = new GroupLookup();
+                gl.populateFromOrg(group);
+                sList += replaceAndWrite(gl);
             }
-		}
-	}
 
-	public class SearchItem
-	{
-		public string name = "";
-		public List<string> values = new List<string>();
+            return sList;
+        }
+    }
 
-		public bool parse = false;
-	}
+    public class FilterItem
+    {
+        public string value;
+    }
+
+    public class GroupLookup
+    {
+        public const string PATTERN_CLEAN = @"\[SGF:\w*\]";
+        public const string PATTERN_CLEAN_CHECKED = @"\[SGF:\w*:\w*\]";
+        public static string[] DAY_LAST = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "", "", "", "Any" };
+
+        public Dictionary<string, string> values = new Dictionary<string, string>();
+
+        public void populateFromOrg(Organization org)
+        {
+            var leader = (from e in DbUtil.Db.People
+                              where e.PeopleId == org.LeaderId
+                              select e).SingleOrDefault();
+
+            values["SGF:OrgID"] = org.OrganizationId.ToString();
+            values["SGF:Name"] = org.OrganizationName;
+            values["SGF:Description"] = org.Description;
+            values["SGF:Room"] = org.Location;
+            values["SGF:Leader"] = org.LeaderName;
+            values["SGF:DateStamp"] = DateTime.Now.ToString("yyyy-MM-dd");
+            values["SGF:Schedule"] = "";
+            values["SGF:Campus"] = org.Campu?.Description;
+
+            if (leader != null && leader.PictureId != null)
+                values["SGF:LeaderPicSrc"] = "/Portrait/" + leader.Picture.SmallId.Value + "?v=" + DateTime.Now.ToString("yyyyMMddHHmmssffff");
+            else
+                values["SGF:LeaderPicSrc"] = "/Portrait/-3";
+
+            if (org.OrgSchedules.Count > 0)
+            {
+                int count = 0;
+                foreach (var schedule in org.OrgSchedules)
+                {
+                    if (count > 0) values["SGF:Schedule"] += "; ";
+                    values["SGF:Schedule"] += DAY_LAST[schedule.SchedDay ?? 0] + ", " + schedule.SchedTime.ToString2("t"); ;
+                    count++;
+                }
+            }
+
+            var loadAllValues = DbUtil.Db.Setting("SGF-LoadAllExtraValues", false);
+
+            foreach (var extra in org.OrganizationExtras)
+            {
+                var val = extra.Data ??
+                          extra.StrValue ??
+                          extra.DateValue?.ToString() ??
+                          extra.IntValue?.ToString() ??
+                          extra.BitValue?.ToString();
+
+                if (extra.Field.StartsWith("SGF:"))
+                    values[extra.Field] = val;
+                else if(loadAllValues)
+                    values[$"SGF:{extra.Field}"] = val;
+            }
+        }
+    }
+
+    public class SearchItem
+    {
+        public string name = "";
+        public List<string> values = new List<string>();
+
+        public bool parse = false;
+    }
 }

--- a/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapIndex.cshtml
+++ b/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapIndex.cshtml
@@ -10,11 +10,11 @@
                 {
                     var f = Model.getFilter(iX);
                     var fi = Model.getFilterItems(iX);
-                    var filterId = Regex.Replace(f.title, "[ /]", "");
+                    var filterId = Regex.Replace(f.name, "[ /]", "");
 
                     <div class="form-group">
                         <label for="@filterId">@f.title</label>
-                        <select id="@filterId" name="@f.title" class="form-control update-control">
+                        <select id="@filterId" name="@f.name" class="form-control update-control">
                             @foreach (var item in fi)
                             {
                                 <option @(Model.IsSelectedValue(f.name, item.value) ? "selected" : "") value="@item.value">@item.value</option>

--- a/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapIndex.cshtml
+++ b/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapIndex.cshtml
@@ -14,7 +14,7 @@
 
                     <div class="form-group">
                         <label for="@filterId">@f.title</label>
-                        <select id="@filterId" name="@filterId" class="form-control update-control">
+                        <select id="@filterId" name="@f.title" class="form-control update-control">
                             @foreach (var item in fi)
                             {
                                 <option @(Model.IsSelectedValue(f.name, item.value) ? "selected" : "") value="@item.value">@item.value</option>


### PR DESCRIPTION
The small group finder had issues when extra values were named with spaces in them - the filter didn't see them and wouldn't show matches. In addition, the replacements wouldn't match either so they didn't work.

The other minor thing is a new admin setting called `UX-HideExtraValueEditForOrgLeaderOnly` that will still let org leaders edit individual extra values, *but* it will prevent them from creating new ones.