### PR TITLE
Minor hiding features for org leaders, customizable filtering of which groups are shown on SGF

### DIFF
--- a/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
@@ -1,8 +1,18 @@
 ﻿@model CmsWeb.Areas.People.Models.EmailModel
+@using CmsData
 @using CmsWeb.Areas.People.Models
 @using UtilityExtensions
 @{
     var access = User.IsInRole("Access");
+    var showEmailDetails = false;
+    if (User.IsInRole("OrgLeadersOnly"))
+    {
+        showEmailDetails = !DbUtil.Db.Setting("UX-HideEmailDetailsForOrgLeaders", false);
+    }
+    else if (User.IsInRole("Access"))
+    {
+        showEmailDetails = true;
+    }
     var sentlabel = Model is EmailScheduledModel ? "Scheduled" : "Sent";
 }
 <form class="non-modal ajax" method="post">
@@ -46,7 +56,7 @@
                                 <td>@i.Count</td>
                             }
                             <td>
-                                @if (access)
+                                @if (showEmailDetails)
                                 {
                                     <a target="viewemail" href="/Emails/Details/@i.Id">@i.Subject</a>
                                 }

--- a/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
@@ -25,7 +25,7 @@
                         <tr>
                             <th>@Model.SortLink(sentlabel)</th>
                             <th>@Model.SortLink("From")</th>
-                            @if (access)
+                            @if (showEmailDetails)
                             {
                                 <th>@Model.SortLink("Count")</th>
                             }
@@ -51,7 +51,7 @@
                                     @i.From<br />
                                 @i.FromAddr
                             </td>
-                            @if (access)
+                            @if (showEmailDetails)
                             {
                                 <td>@i.Count</td>
                             }

--- a/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
@@ -1,57 +1,69 @@
-﻿@using CmsWeb.Areas.People.Models
+﻿@using CmsData
+@using CmsWeb.Areas.People.Models
 @using UtilityExtensions
 @model FamilyModel
-<div id="family-div">
-  <div class="row">
-    <div class="col-sm-12">
-      @if (User.IsInRole("Access"))
-      {
-          <h4>
-            <a id="family-members-collapse" data-toggle="collapse" href="#family-members-section" aria-expanded="true" aria-controls="family-members-section"><i class="fa fa-chevron-circle-down"></i></a> <a href="/Person2/FamilyQuery/@Model.Family.FamilyId">Family Members</a>
-          </h4>
-      }
-      else
-      {
-          <h4>
-            <a id="family-members-collapse" data-toggle="collapse" href="#family-members-section" aria-expanded="true" aria-controls="family-members-section"><i class="fa fa-chevron-circle-down"></i></a> Family Members
-          </h4>
-      }
-    </div>
-  </div>
-  <div class="row collapse in" id="family-members-section">
-    <div class="col-sm-12">
-      <ul id="family_members" class="nav nav-stacked nav-tabs nav-tabs-left" style="margin-bottom: 10px;">
-        @foreach (var m in Model.ViewList())
-        {
-          var active = m.Id == Model.Person.PeopleId ? "active" : "";
-          var ifdeceased = !active.HasValue() && m.IsDeceased == true ? "alert alert-danger" : "";
-          var picdt = (m.PicDate ?? DateTime.Now);
-          var portraitUrl = $"/Portrait/{m.PortraitId}?v={picdt.Ticks}";
-          var portraitBgPos = m.PicXPos.HasValue || m.PicYPos.HasValue ? $"{m.PicXPos ?? 0}% {m.PicYPos ?? 0}%" : "top";
-            <li class="@active @ifdeceased" style="font-size: 0.85em;">
-              <a href="/Person2/@m.Id">
-                <div class="headshot" style="background-image:url(@portraitUrl); background-position: @portraitBgPos"></div>
-                <span class="name">@m.Name @Html.Raw(m.SpouseIndicator)</span><br />
-                <span class="meta">
-                  <span class="age">@m.Age</span>
-                  &bull; <span class="status">@m.MemberStatus</span>
-                  &bull; <span class="role">@m.PositionInFamily</span>
-                </span>
-                <div class="email email_display truncate">@m.Email</div>
-              </a>
-            </li>
-        }
-      </ul>
-    </div>
-    @if (Model.Person.CanUserEditAll)
+@{
+    var showFamilyQueryLink = false;
+    if (User.IsInRole("OrgLeadersOnly"))
     {
-        <div class="col-sm-12">
-          <a href="/SearchAdd2/Dialog/Family/@Model.Person.PeopleId" class="searchadd btn btn-success btn-sm btn-block"><i class="fa fa-plus-circle"></i>&nbsp;&nbsp;Add Family Member</a>
-        </div>
-
+        showFamilyQueryLink = !DbUtil.Db.Setting("UX-HideQueriesForOrgLeaders", false);
     }
-    <div class="col-sm-12">
-      <br />
+    else if (User.IsInRole("Access"))
+    {
+        showFamilyQueryLink = true;
+    }
+}
+<div id="family-div">
+    <div class="row">
+        <div class="col-sm-12">
+            @if (showFamilyQueryLink)
+            {
+                <h4>
+                    <a id="family-members-collapse" data-toggle="collapse" href="#family-members-section" aria-expanded="true" aria-controls="family-members-section"><i class="fa fa-chevron-circle-down"></i></a> <a href="/Person2/FamilyQuery/@Model.Family.FamilyId">Family Members</a>
+                </h4>
+            }
+            else
+            {
+                <h4>
+                    <a id="family-members-collapse" data-toggle="collapse" href="#family-members-section" aria-expanded="true" aria-controls="family-members-section"><i class="fa fa-chevron-circle-down"></i></a> Family Members
+                </h4>
+            }
+        </div>
     </div>
-  </div>
+    <div class="row collapse in" id="family-members-section">
+        <div class="col-sm-12">
+            <ul id="family_members" class="nav nav-stacked nav-tabs nav-tabs-left" style="margin-bottom: 10px;">
+                @foreach (var m in Model.ViewList())
+                {
+                    var active = m.Id == Model.Person.PeopleId ? "active" : "";
+                    var ifdeceased = !active.HasValue() && m.IsDeceased == true ? "alert alert-danger" : "";
+                    var picdt = (m.PicDate ?? DateTime.Now);
+                    var portraitUrl = $"/Portrait/{m.PortraitId}?v={picdt.Ticks}";
+                    var portraitBgPos = m.PicXPos.HasValue || m.PicYPos.HasValue ? $"{m.PicXPos ?? 0}% {m.PicYPos ?? 0}%" : "top";
+                    <li class="@active @ifdeceased" style="font-size: 0.85em;">
+                        <a href="/Person2/@m.Id">
+                            <div class="headshot" style="background-image:url(@portraitUrl); background-position: @portraitBgPos"></div>
+                            <span class="name">@m.Name @Html.Raw(m.SpouseIndicator)</span><br />
+                            <span class="meta">
+                                <span class="age">@m.Age</span>
+                                &bull; <span class="status">@m.MemberStatus</span>
+                                &bull; <span class="role">@m.PositionInFamily</span>
+                            </span>
+                            <div class="email email_display truncate">@m.Email</div>
+                        </a>
+                    </li>
+                }
+            </ul>
+        </div>
+        @if (Model.Person.CanUserEditAll)
+        {
+            <div class="col-sm-12">
+                <a href="/SearchAdd2/Dialog/Family/@Model.Person.PeopleId" class="searchadd btn btn-success btn-sm btn-block"><i class="fa fa-plus-circle"></i>&nbsp;&nbsp;Add Family Member</a>
+            </div>
+
+        }
+        <div class="col-sm-12">
+            <br />
+        </div>
+    </div>
 </div>

--- a/CmsWeb/Areas/People/Views/Person/Family/Related.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Family/Related.cshtml
@@ -1,7 +1,17 @@
-﻿@using CmsWeb.Areas.People.Models
+﻿@using CmsData
+@using CmsWeb.Areas.People.Models
 @model FamilyModel
 @{
     var dialog = "/SearchAdd2/Dialog/RelatedFamily/" + Model.Person.PeopleId;
+    var showFamilyQueryLink = false;
+    if (User.IsInRole("OrgLeadersOnly"))
+    {
+        showFamilyQueryLink = !DbUtil.Db.Setting("UX-HideQueriesForOrgLeaders", false);
+    }
+    else if (User.IsInRole("Access"))
+    {
+        showFamilyQueryLink = true;
+    }
 }
 <div id="related-families-div">
     @if (!Model.RelatedFamilies().Any())
@@ -27,7 +37,14 @@
     {
         <div class="row">
             <div class="col-sm-12">
-                <h4><a id="related-family-collapse" data-toggle="collapse" href="#related-family-section" aria-expanded="true" aria-controls="related-family-section"><i class="fa fa-chevron-circle-down"></i></a> <a href="/Person2/RelatedFamilyQuery/@Model.Family.FamilyId">Related Families</a></h4>
+                @if (showFamilyQueryLink)
+                {
+                    <h4><a id="related-family-collapse" data-toggle="collapse" href="#related-family-section" aria-expanded="true" aria-controls="related-family-section"><i class="fa fa-chevron-circle-down"></i></a> <a href="/Person2/RelatedFamilyQuery/@Model.Family.FamilyId">Related Families</a></h4>
+                }
+                else
+                {
+                    <h4><a id="related-family-collapse" data-toggle="collapse" href="#related-family-section" aria-expanded="true" aria-controls="related-family-section"><i class="fa fa-chevron-circle-down"></i></a> Related Families</h4>
+                }
             </div>
         </div>
         <div class="row collapse in" id="related-family-section">

--- a/CmsWeb/Areas/People/Views/Person/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Index.cshtml
@@ -15,10 +15,15 @@
     {
         showResourcesTab = Model.PeopleId == Util.UserPeopleId || User.IsInRole("ViewResources");
     }
-    var showMinistryTab = User.IsInRole("Access");
-    if (!(User.IsInRole("OrgLeadersOnly") && !DbUtil.Db.Setting("UX-HideMinistryTabForOrgLeaders", false)))
+
+    var showMinistryTab = false;
+    if (User.IsInRole("OrgLeadersOnly"))
     {
-        showMinistryTab = false;
+        showMinistryTab = !DbUtil.Db.Setting("UX-HideMinistryTabForOrgLeaders", false);
+    }
+    else if (User.IsInRole("Access"))
+    {
+        showMinistryTab = true;
     }
 }
 @section head

--- a/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
+++ b/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
@@ -277,7 +277,7 @@ namespace CmsWeb.Areas.Public.Models
                            where g.Campu.Description == filter.Value.values[0]
                            select g;
                 }
-                else if (filter.Key == "Time")
+                else if (filter.Key.EndsWith("Time"))
                 {
                     var val = filter.Value.values[0];
                     orgs = from g in orgs

--- a/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapContent.cshtml
+++ b/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapContent.cshtml
@@ -7,6 +7,14 @@
     var latitude = double.Parse(Model.getSetting("Latitude")?.value ?? "40.757577");
     var longitude = double.Parse(Model.getSetting("Longitude")?.value ?? "-73.969246");
     var mapZoom = int.Parse(Model.getSetting("MapZoom")?.value ?? "12");
+
+    var showOnlyName = Model.getSetting("ShowOnlyName")?.value;
+    var showOnlyValue = Model.getSetting("ShowOnlyValue")?.value;
+
+    if (!string.IsNullOrWhiteSpace(showOnlyName) && !string.IsNullOrWhiteSpace(showOnlyValue))
+    {
+        mapModel.SetShowOnly(showOnlyName, showOnlyValue);
+    }
 }
 
 <div class="row map-content">


### PR DESCRIPTION
@davidcarroll FYI, Redeemer has tested these changes on the staging site.

The customizable filtering of organizations on the small group finder is now based on new settings:

```
<SGFSetting name="ShowOnlyName" value="NAME_TO_FILTER_ON" />
<SGFSetting name="ShowOnlyValue" value="VALUE_TO_FILTER_ON" />
```

Basically, it looks for an org extra value named "NAME_TO_FILTER_ON" with a value of "VALUE_TO_FILTER_ON" before it returns it.

In addition, this includes fixes for the ministry tab hiding. I used the same pattern for some other minor admin settings to optionally hide some settings from org leaders.

These settings are:
* `UX-HideEmailDetailsForOrgLeaders`
* `UX-HideQueriesForOrgLeaders`

As I said, this also fixes the prior bug with `UX-HideMinistryTabForOrgLeaders`. The basic boolean pattern I'm now using to ensure that we don't inadvertently hide tabs from all access users is:

```csharp
// default to false
var showTab = false;

// see if they're org leaders...
if (User.IsInRole("OrgLeadersOnly"))
{
    // then only show it if the setting is not true (defaults to false)
    showTab = !DbUtil.Db.Setting("UX-TabSetting", false);
}
// otherwise if they're access role
else if (User.IsInRole("Access"))
{
    // they just get it
    showTab = true;
}
```