### PR TITLE
Fix issue with SGF time filtering

### DIFF
--- a/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
+++ b/CmsWeb/Areas/Public/Models/SmallGroupFinderModel.cs
@@ -282,7 +282,7 @@ namespace CmsWeb.Areas.Public.Models
                     var val = filter.Value.values[0];
                     orgs = from g in orgs
                            where g.OrganizationExtras
-                              .Any(oe => oe.Field == "Time" &&
+                              .Any(oe => oe.Field == filter.Key &&
                                   (
                                       oe.StrValue.ToLower().EndsWith(val) ||
                                       oe.Data.ToLower().EndsWith(val) ||


### PR DESCRIPTION
We missed one thing when comparing times (AM/PM) because of a missed hard-coded `"Time"`.