### PR TITLE
Allow for customization for marker text

### DIFF
--- a/CmsWeb/Areas/Public/Models/SGMapModel.cs
+++ b/CmsWeb/Areas/Public/Models/SGMapModel.cs
@@ -32,12 +32,24 @@ namespace CmsWeb.Models
 
         private string showOnlyName;
         private string showOnlyValue;
+
+        private string markerName;
+        private string markerValue;
+        private string markerText;
+
         private readonly bool _isInitialSearchResult;
 
         public void SetShowOnly(string name, string value)
         {
             showOnlyName = name;
             showOnlyValue = value;
+        }
+
+        public void SetMarkerText(string name, string value, string text)
+        {
+            markerName = name;
+            markerValue = value;
+            markerText = text;
         }
 
         public IEnumerable<SGInfo> SmallGroupInfo()
@@ -90,7 +102,14 @@ namespace CmsWeb.Models
                          id = i.o.OrganizationId,
                          gc = geocode,
                          org = i.o,
-                         markertext = i.o.OrganizationExtras.SingleOrDefault(oe => oe.Field == "Term")?.Data == "Beta Group" ? "B" : " ",
+                         markertext = i.o.OrganizationExtras
+                                         .Where(oe => oe.Field == markerName)
+                                         .Select(oe => oe.StrValue ??
+                                            oe.Data ??
+                                            oe.DateValue?.ToString() ??
+                                            oe.IntValue?.ToString() ??
+                                            oe.BitValue?.ToString()
+                                         ).Select(x => x == markerValue ? markerText : " ").SingleOrDefault(),
                          color = DbUtil.Db.Setting($"UX-MapPinColor-Campus-{i.o.CampusId.GetValueOrDefault(-1)}", "FFFFFF").Replace("#", "")
                      };
             return q2.Where(x => !string.IsNullOrWhiteSpace(x.addr)).ToList();

--- a/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapContent.cshtml
+++ b/CmsWeb/Areas/Public/Views/SmallGroupFinder/MapContent.cshtml
@@ -11,9 +11,20 @@
     var showOnlyName = Model.getSetting("ShowOnlyName")?.value;
     var showOnlyValue = Model.getSetting("ShowOnlyValue")?.value;
 
+    var markerName = Model.getSetting("MarkerTextName")?.value;
+    var markerValue = Model.getSetting("MarkerTextValue")?.value;
+    var markerText = Model.getSetting("MarkerText")?.value;
+
     if (!string.IsNullOrWhiteSpace(showOnlyName) && !string.IsNullOrWhiteSpace(showOnlyValue))
     {
         mapModel.SetShowOnly(showOnlyName, showOnlyValue);
+    }
+
+    if (!string.IsNullOrWhiteSpace(markerName) &&
+        !string.IsNullOrWhiteSpace(markerValue) &&
+        !string.IsNullOrWhiteSpace(markerText))
+    {
+        mapModel.SetMarkerText(markerName, markerValue, markerText);
     }
 }
 


### PR DESCRIPTION
We caught an issue where we were hard-coding the check for marker text. In addition, it didn't support string, code, date, bit, etc. types of extra values.

This adds new SGF settings like below:

```xml
<SGFSetting name="MarkerTextName" value="Group Term" />
<SGFSetting name="MarkerTextValue" value="Beta Group" />
<SGFSetting name="MarkerText" value="B" />
```

Basically, it says if you find the name of `Group Term` for an extra value with a value of `Beta Group` then show `B`.