### PR TITLE
CustomAccessRoles - refactoring of admin settings to special content

### DIFF
--- a/CmsData/Classes/ExtraValues/Value.cs
+++ b/CmsData/Classes/ExtraValues/Value.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Web;
 using System.Xml.Serialization;
+using CmsData.Classes.RoleChecker;
 using UtilityExtensions;
 
 namespace CmsData.ExtraValue
@@ -48,7 +49,7 @@ namespace CmsData.ExtraValue
                 if (user.IsInRole("Edit"))
                     return true;
 
-                if (user.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs"))
+                if (RoleChecker.HasSetting(SettingName.CanEditCGInfoEVs, false))
                 {
                     if (string.IsNullOrEmpty(EditableRoles))
                         return true;

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -1,31 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Web;
 using System.Xml.Linq;
-using System.Xml.Serialization;
-using IronPython.Modules;
 
 namespace CmsData.Classes.RoleChecker
 {
     public static class RoleChecker
     {
-        private static XDocument xdoc
+        private static XDocument Xdoc
         {
             get
             {
+                const string CustomAccessRolesKey = "CustomAccessRoles.xml";
                 try
                 {
-                    return XDocument.Load(new StringReader(DbUtil.Content("CustomAccessRoles.xml", "")));
+                    var doc = HttpContext.Current.Items[CustomAccessRolesKey] as XDocument;
+                    if (doc == null)
+                    {
+                        doc = XDocument.Load(new StringReader(DbUtil.Content(CustomAccessRolesKey, "")));
+                        HttpContext.Current.Items[CustomAccessRolesKey] = doc;
+                    }
+                    return doc;
                 }
                 catch
                 {
-                    return new XDocument();
+                    var doc = new XDocument();
+                    HttpContext.Current.Items[CustomAccessRolesKey] = doc;
+                    return doc;
                 }
             }
         }
-        private static XElement roles => xdoc.Element("roles");
+        private static XElement Roles => Xdoc.Element("roles");
 
         private static XElement Settings(XElement role)
         {
@@ -34,6 +38,8 @@ namespace CmsData.Classes.RoleChecker
 
         public static bool HasSetting(SettingName setting, bool defaultValue)
         {
+            var roles = Roles;
+
             if (roles != null)
             {
                 foreach (var r in roles.Elements("role"))

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -67,6 +67,7 @@ namespace CmsData.Classes.RoleChecker
 
     public enum SettingName
     {
+        // ReSharper disable InconsistentNaming
         Person_ShowBlueToolbar,
         Organization_ShowSettingsTab,
         Organization_ShowBlueToolbar,
@@ -102,7 +103,6 @@ namespace CmsData.Classes.RoleChecker
         Meeting_ShowAttendType,
         Meeting_ShowOtherAttend,
         Meeting_ShowCurrentMemberType,
-        AutoOrgLeaderPromoteCustom,
         AutoOrgLeaderPromotion,
         DisableHomePage,
         DisablePersonLinks,
@@ -117,12 +117,12 @@ namespace CmsData.Classes.RoleChecker
         LeadersCanAlwaysEditOrgContent,
         LimitToolbar,
         LimitedSearchPerson,
-        CollapseOrgDetails,
         CanEditCGInfoEVs,
         EditMemberData,
         OrgMembersDropAdd,
         OtherGroupsContentOnly,
         ShowChildOrgsOnInvolvementTabs,
         ShowParentOrgInDetails
+        // ReSharper restore InconsistentNaming
     }
 }

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using IronPython.Modules;
+
+namespace CmsData.Classes.RoleChecker
+{
+    public static class RoleChecker
+    {
+        private static XDocument xdoc
+        {
+            get
+            {
+                try
+                {
+                    return XDocument.Load(new StringReader(DbUtil.Content("CustomAccessRoles.xml", "")));
+                }
+                catch
+                {
+                    return new XDocument();
+                }
+            }
+        }
+        private static XElement roles => xdoc.Element("roles");
+
+        private static XElement Settings(XElement role)
+        {
+            return role.Element("settings");
+        }
+
+        public static bool HasSetting(SettingName setting, bool defaultValue)
+        {
+            if (roles != null)
+            {
+                foreach (var r in roles.Elements("role"))
+                {
+                    var roleName = r.Attribute("name");
+                    if (!HttpContext.Current.User.IsInRole(roleName?.Value)) continue;
+
+                    foreach (var s in Settings(r).Elements())
+                    {
+                        var nameAttribute = s.Attribute("name");
+                        var valueAttribute = s.Attribute("value");
+                        if (nameAttribute?.Value == SettingNameAsString(setting))
+                        {
+                            bool value;
+                            if (bool.TryParse(valueAttribute?.Value, out value)) return value;
+                        }
+                    }
+                }
+            }
+
+            return defaultValue;
+        }
+
+        private static string SettingNameAsString(SettingName setting)
+        {
+            return setting
+                    .ToString()
+                    .Replace('_', '-');
+        }
+    }
+
+    public enum SettingName
+    {
+        Person_ShowBlueToolbar,
+        Organization_ShowSettingsTab,
+        Organization_ShowBlueToolbar,
+        Organization_ShowBlueToolbarFullEmailMenu,
+        Organization_ShowBlueToolbarEmailMembers,
+        Organization_ShowBlueToolbarEmailProspects,
+        Organization_ShowBlueToolbarEmailMembersAndProspects,
+        Organization_ShowBlueToolbarExportMenu,
+        Organization_ShowBlueToolbarCustomReportsMenu,
+        Organization_ShowBlueToolbarAdminGearMenu,
+        Organization_ShowBlueToolbarSubGroupManagement,
+        Organization_ShowBlueToolbarMembersOnlyPage,
+        Organization_ShowBlueToolbarVolunteerCalendar,
+        Organization_ShowOptionsMenu,
+        Organization_ShowFiltersBar,
+        Organization_CollapseOrgDetails,
+        Organization_ShowBirthday,
+        Organization_ShowAddress,
+        Organization_ShowCreateNewMeeting,
+        Organization_ShowDeleteMeeting,
+        Organization_ShowTagButtons,
+        Meeting_HyperlinkNames,
+        Meeting_ShowAddGuest,
+        Meeting_AllowEditDescription,
+        Meeting_ShowExtraValuesBox,
+        Meeting_ShowWandTargetBox,
+        Meeting_ShowBlueToolbar,
+        Meeting_ShowBlueToolbarIpadAttendance,
+        Meeting_ShowBlueToolbarRollsheet,
+        Meeting_EnableEditByDefault,
+        Meeting_ShowEnableBox,
+        Meeting_ShowShowBox,
+        Meeting_ShowAttendType,
+        Meeting_ShowOtherAttend,
+        Meeting_ShowCurrentMemberType,
+        AutoOrgLeaderPromoteCustom,
+        AutoOrgLeaderPromotion,
+        DisableHomePage,
+        DisablePersonLinks,
+        HideEmailDetails,
+        HideExtraValueEdit,
+        HideGuestsOrgMembers,
+        HideInactiveOrgMembers,
+        HideMinistryTab,
+        HideNavTabs,
+        HidePendingOrgMembers,
+        HideQueries,
+        LeadersCanAlwaysEditOrgContent,
+        LimitToolbar,
+        LimitedSearchPerson,
+        CollapseOrgDetails,
+        CanEditCGInfoEVs,
+        EditMemberData,
+        OrgMembersDropAdd,
+        OtherGroupsContentOnly,
+        ShowChildOrgsOnInvolvementTabs,
+        ShowParentOrgInDetails
+    }
+}

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -78,7 +78,6 @@ namespace CmsData.Classes.RoleChecker
         Organization_ShowBlueToolbarExportMenu,
         Organization_ShowBlueToolbarCustomReportsMenu,
         Organization_ShowBlueToolbarAdminGearMenu,
-        Organization_ShowBlueToolbarSubGroupManagement,
         Organization_ShowBlueToolbarMembersOnlyPage,
         Organization_ShowBlueToolbarVolunteerCalendar,
         Organization_ShowOptionsMenu,

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -120,9 +120,7 @@ namespace CmsData.Classes.RoleChecker
         CanEditCGInfoEVs,
         EditMemberData,
         OrgMembersDropAdd,
-        OtherGroupsContentOnly,
-        ShowChildOrgsOnInvolvementTabs,
-        ShowParentOrgInDetails
+        OtherGroupsContentOnly
         // ReSharper restore InconsistentNaming
     }
 }

--- a/CmsData/CmsData.csproj
+++ b/CmsData/CmsData.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Classes\GoogleCloudMessaging\GCMResponseResult.cs" />
     <Compile Include="Classes\OnlineRegSummaryText\OnlineRegPersonModel0.cs" />
     <Compile Include="Classes\OnlineRegSummaryText\SummaryInfo.cs" />
+    <Compile Include="Classes\RoleChecker\RoleChecker.cs" />
     <Compile Include="Classes\style.cs" />
     <Compile Include="DbUtil\CurrentOrg.cs" />
     <Compile Include="DbUtil\ModelViewModel.cs" />

--- a/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberModel.cs
@@ -24,6 +24,7 @@ namespace CmsWeb.Areas.Dialog.Models
         private int? orgId;
         private int? peopleId;
 
+        private const string AutoOrgLeaderPromotion = "AutoOrgLeaderPromotion";
         private const string AutoOrgLeaderPromoteCustom = "AutoOrgLeaderPromoteCustom";
         private const int DefaultLeaderMemberTypeId = 140;
         private const string AccessRole = "Access";
@@ -378,7 +379,7 @@ Checking the Remove From Enrollment History box will erase all enrollment histor
 
         private void CheckForAutoPromotion()
         {
-            var autoLeaderOrgPromotionSetting = RoleChecker.HasSetting(SettingName.AutoOrgLeaderPromotion, false);
+            var autoLeaderOrgPromotionSetting = DbUtil.Db.Setting(AutoOrgLeaderPromotion);
             if (!autoLeaderOrgPromotionSetting) return;
 
             var isPromotingToLeader = !LeaderTypeIds.Contains(OrgMember.MemberTypeId.ToString()) &&
@@ -411,7 +412,7 @@ Checking the Remove From Enrollment History box will erase all enrollment histor
 
         private void CheckForAutoDemotion()
         {
-            var autoLeaderOrgPromotionSetting = RoleChecker.HasSetting(SettingName.AutoOrgLeaderPromotion, false);
+            var autoLeaderOrgPromotionSetting = DbUtil.Db.Setting(AutoOrgLeaderPromotion);
             if (!autoLeaderOrgPromotionSetting) return;
 
             var autoPromoteCustom = GetAutoPromoteCustomSetting();

--- a/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using CmsData;
+using CmsData.Classes.RoleChecker;
 using CmsData.Codes;
 using CmsData.OnlineRegSummaryText;
 using CmsData.Registration;
@@ -23,7 +24,6 @@ namespace CmsWeb.Areas.Dialog.Models
         private int? orgId;
         private int? peopleId;
 
-        private const string AutoOrgLeaderPromotion = "AutoOrgLeaderPromotion";
         private const string AutoOrgLeaderPromoteCustom = "AutoOrgLeaderPromoteCustom";
         private const int DefaultLeaderMemberTypeId = 140;
         private const string AccessRole = "Access";
@@ -378,7 +378,7 @@ Checking the Remove From Enrollment History box will erase all enrollment histor
 
         private void CheckForAutoPromotion()
         {
-            var autoLeaderOrgPromotionSetting = DbUtil.Db.Setting(AutoOrgLeaderPromotion);
+            var autoLeaderOrgPromotionSetting = RoleChecker.HasSetting(SettingName.AutoOrgLeaderPromotion, false);
             if (!autoLeaderOrgPromotionSetting) return;
 
             var isPromotingToLeader = !LeaderTypeIds.Contains(OrgMember.MemberTypeId.ToString()) &&
@@ -411,7 +411,7 @@ Checking the Remove From Enrollment History box will erase all enrollment histor
 
         private void CheckForAutoDemotion()
         {
-            var autoLeaderOrgPromotionSetting = DbUtil.Db.Setting(AutoOrgLeaderPromotion);
+            var autoLeaderOrgPromotionSetting = RoleChecker.HasSetting(SettingName.AutoOrgLeaderPromotion, false);
             if (!autoLeaderOrgPromotionSetting) return;
 
             var autoPromoteCustom = GetAutoPromoteCustomSetting();

--- a/CmsWeb/Areas/Dialog/Views/OrgMemberDialog/Tabs/MemberData.cshtml
+++ b/CmsWeb/Areas/Dialog/Views/OrgMemberDialog/Tabs/MemberData.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsData.Codes
 @using UtilityExtensions
 @model CmsWeb.Areas.Dialog.Models.OrgMemberModel
@@ -8,7 +9,7 @@
   var leader = peopleId.HasValue && DbUtil.Db.OrganizationMembers.Any(x => x.PeopleId == peopleId.Value && x.MemberType.AttendanceTypeId == AttendTypeCode.Leader);
 
   var managetransactions = User.IsInRole("ManageTransactions");
-  var edit = User.IsInRole("Edit") || (leader && DbUtil.Db.Setting("UX-OrgLeadersOnlyEditMemberData"));
+  var edit = User.IsInRole("Edit") || (leader && RoleChecker.HasSetting(SettingName.EditMemberData, false));
   var missiongiving = User.IsInRole("MissionGiving") || User.IsInRole("Developer");
   var member = Model.Group == "Member";
   var sender = Model.Group == "Inactive" && Model.Organization.IsMissionTrip == true;

--- a/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
@@ -1,5 +1,6 @@
 ﻿@using System.Configuration
 @using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsData.Codes
 @model CmsWeb.Areas.Main.Models.MassEmailer
 @{
@@ -11,7 +12,7 @@
     //c.TypeID == ContentTypeCode.TypeEmailTemplate
     //the above means that it was a template they chose if true and a draft they chose if false
 
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
 }
 @section head
 {

--- a/CmsWeb/Areas/Main/Views/Email/Index.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Index.cshtml
@@ -1,13 +1,14 @@
 ﻿@model CmsWeb.Areas.Main.Models.MassEmailer
 @using System.Configuration
 @using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb
 @{
   Layout = ViewExtensions2.TouchPointLayout();
   ViewBag.Title = "Email";
   ViewBag.PageHeader = "Email";
 
-  var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+  var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, true);
 }
 @section head
 {

--- a/CmsWeb/Areas/Org/Models/MeetingModel.cs
+++ b/CmsWeb/Areas/Org/Models/MeetingModel.cs
@@ -5,6 +5,7 @@ using CmsData;
 using UtilityExtensions;
 using CmsWeb.Areas.Reports.Models;
 using System.Collections;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.Org.Models
 {
@@ -20,6 +21,21 @@ namespace CmsWeb.Areas.Org.Models
         public bool sortbyname { get; set; }
         public bool showlarge { get; set; }
         public bool CommitsOnly { get; set; }
+
+        public bool HyperlinkNames => RoleChecker.HasSetting(SettingName.Meeting_HyperlinkNames, true);
+        public bool ShowAddGuest => RoleChecker.HasSetting(SettingName.Meeting_ShowAddGuest, true);
+        public bool AllowEditDescription => RoleChecker.HasSetting(SettingName.Meeting_AllowEditDescription, true);
+        public bool ShowExtraValuesBox => RoleChecker.HasSetting(SettingName.Meeting_ShowExtraValuesBox, true);
+        public bool ShowWandTargetBox => RoleChecker.HasSetting(SettingName.Meeting_ShowWandTargetBox, true);
+        public bool ShowBlueToolbar => RoleChecker.HasSetting(SettingName.Meeting_ShowBlueToolbar, true);
+        public bool ShowBlueToolbarIpadAttendance => RoleChecker.HasSetting(SettingName.Meeting_ShowBlueToolbarIpadAttendance, true);
+        public bool ShowBlueToolbarRollsheet => RoleChecker.HasSetting(SettingName.Meeting_ShowBlueToolbarRollsheet, true);
+        public bool EnableEditByDefault => RoleChecker.HasSetting(SettingName.Meeting_EnableEditByDefault, false);
+        public bool ShowEnableBox => RoleChecker.HasSetting(SettingName.Meeting_ShowEnableBox, true);
+        public bool ShowShowBox => RoleChecker.HasSetting(SettingName.Meeting_ShowShowBox, true);
+        public bool ShowAttendType => RoleChecker.HasSetting(SettingName.Meeting_ShowAttendType, true);
+        public bool ShowOtherAttend => RoleChecker.HasSetting(SettingName.Meeting_ShowOtherAttend, true);
+        public bool ShowCurrentMemberType => RoleChecker.HasSetting(SettingName.Meeting_ShowCurrentMemberType, true);
 
         public MeetingModel(int id)
         {

--- a/CmsWeb/Areas/Org/Models/Org/MeetingsModel.cs
+++ b/CmsWeb/Areas/Org/Models/Org/MeetingsModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using CmsData;
 using CmsWeb.Models;
 using UtilityExtensions;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.Org.Models
 {
@@ -10,6 +11,9 @@ namespace CmsWeb.Areas.Org.Models
     {
         public int Id { get; set; }
         public bool Future { get; set; }
+
+        public bool ShowCreateNewMeeting => RoleChecker.HasSetting(SettingName.Organization_ShowCreateNewMeeting, true);
+        public bool ShowDeleteMeeting => RoleChecker.HasSetting(SettingName.Organization_ShowDeleteMeeting, true);
 
         public MeetingsModel() 
             : base("", "", true) { }

--- a/CmsWeb/Areas/Org/Models/Org/OrgMain.cs
+++ b/CmsWeb/Areas/Org/Models/Org/OrgMain.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Web;
 using CmsData;
+using CmsData.Classes.RoleChecker;
 using CmsWeb.Code;
 using CmsWeb.Models;
 using UtilityExtensions;
@@ -53,7 +54,7 @@ namespace CmsWeb.Areas.Org.Models
             }
         }
 
-        public bool CollapsedOrganizationDetails => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeaderLimitedSearchPerson");
+        public bool CollapsedOrganizationDetails => RoleChecker.HasSetting(SettingName.Organization_CollapseOrgDetails, false);
 
         private string _schedule;
         public string Schedule

--- a/CmsWeb/Areas/Org/Models/Org/OrgPeopleModel.cs
+++ b/CmsWeb/Areas/Org/Models/Org/OrgPeopleModel.cs
@@ -9,6 +9,7 @@ using UtilityExtensions;
 using System.Web.Mvc;
 using CmsData.Codes;
 using CmsData.View;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.Org.Models
 {
@@ -277,20 +278,23 @@ namespace CmsWeb.Areas.Org.Models
         public string ShowAddressActive => ShowAddress ? "active" : "";
         public string FilterTagActive => FilterTag ? "active" : "";
         public string FilterIndActive => FilterIndividuals ? "active" : "";
-        public bool ShowPeopleLink => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-DisablePersonLinksForOrgLeaders");
-        public bool OrgLeaderAddDrop => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeadersOnlyOrgMembersDropAdd");
-        public bool HideInactiveButton => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-HideInactiveOrgMembersForOrgLeadersOnly");
-        public bool HidePendingButton => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-HidePendingOrgMembersForOrgLeadersOnly");
-        public bool HideGuestsButton => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-HideGuestsOrgMembersForOrgLeadersOnly");
-        public bool HideOptionsButton => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeaderLimitedSearchPerson");
-        public bool HideFilterOptions => HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeaderLimitedSearchPerson");
+        public bool DisablePeopleLink => RoleChecker.HasSetting(SettingName.DisablePersonLinks, false);
+        public bool OrgLeaderAddDrop => RoleChecker.HasSetting(SettingName.OrgMembersDropAdd, false);
+        public bool HideInactiveButton => RoleChecker.HasSetting(SettingName.HideInactiveOrgMembers, false);
+        public bool HidePendingButton => RoleChecker.HasSetting(SettingName.HidePendingOrgMembers, false);
+        public bool HideGuestsButton => RoleChecker.HasSetting(SettingName.HideGuestsOrgMembers, false);
+
+        public bool ShowOptions => RoleChecker.HasSetting(SettingName.Organization_ShowOptionsMenu, true);
+        public bool ShowSubgroupFilters => RoleChecker.HasSetting(SettingName.Organization_ShowFiltersBar, true);
+        public bool ShowBirthday => RoleChecker.HasSetting(SettingName.Organization_ShowBirthday, true);
+        public bool ShowAddress => RoleChecker.HasSetting(SettingName.Organization_ShowAddress, true);
+        public bool ShowTagButtons => RoleChecker.HasSetting(SettingName.Organization_ShowTagButtons, true);
 
         public int? Id { get; set; }
         public string GroupSelect { get; set; }
         public string NameFilter { get; set; }
         public string SgFilter { get; set; }
         public bool ShowHidden { get; set; }
-        public bool ShowAddress { get; set; }
         public bool FilterTag { get; set; }
         public bool FilterIndividuals { get; set; }
         public bool ClearFilter { get; set; }
@@ -341,9 +345,8 @@ to `Add`, `Drop`, `Update` Members etc.
         public bool Showdrop(string group)
         {
             var u = HttpContext.Current.User;
-            var orgLeader = u.IsInRole("OrgLeadersOnly");
 
-            return (u.IsInRole("Edit") || (orgLeader && DbUtil.Db.Setting("UX-OrgLeadersOnlyOrgMembersDropAdd"))) &&
+            return (u.IsInRole("Edit") || RoleChecker.HasSetting(SettingName.OrgMembersDropAdd, true)) &&
                 (MultiSelect ? "" : GroupSelect) == group;
         }
     }

--- a/CmsWeb/Areas/Org/Models/Org/OrganizationModel.cs
+++ b/CmsWeb/Areas/Org/Models/Org/OrganizationModel.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using System.Web;
 using CmsData;
 using System.Web.Mvc;
-using CmsData.Registration;
 using CmsData.View;
 using CmsWeb.Code;
 using UtilityExtensions;
 using System.Text.RegularExpressions;
+using CmsData.Classes.RoleChecker;
 using CmsData.Codes;
+using Settings = CmsData.Registration.Settings;
 
 namespace CmsWeb.Areas.Org.Models
 {
@@ -164,16 +165,19 @@ namespace CmsWeb.Areas.Org.Models
             return _showContactsReceivedTab.Value;
         }
 
-        public bool ShowSettingsTab
-        {
-            get
-            {
-                if (!HttpContext.Current.User.IsInRole("OrgLeadersOnly"))
-                    return true;
-
-                return !DbUtil.Db.Setting("UX-HideSettingsTabForOrgLeaders");
-            }
-        }
+        public bool ShowBlueToolbar => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbar, true);
+        public bool ShowBlueToolbarFullEmail => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarFullEmailMenu, true);
+        public bool ShowBlueToolbarEmailMembers => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarEmailMembers, true);
+        public bool ShowBlueToolbarEmailProspects => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarEmailProspects, true);
+        public bool ShowBlueToolbarEmailMembersAndProspects => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarEmailMembersAndProspects, true);
+        public bool ShowBlueToolbarExports => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarExportMenu, true);
+        public bool ShowBlueToolbarCustomReports => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarCustomReportsMenu, true);
+        public bool ShowBlueToolbarAdminGear => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarAdminGearMenu, true);
+        public bool ShowBlueToolbarSubGroupManagement => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarSubGroupManagement, true);
+        public bool ShowBlueToolbarMembersOnlyPage => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarMembersOnlyPage, true);
+        public bool ShowBlueToolbarVolunteerCalendar => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarVolunteerCalendar, true);
+        
+        public bool ShowSettingsTab => RoleChecker.HasSetting(SettingName.Organization_ShowSettingsTab, true);
 
         public bool ShowMeetingsTab
         {
@@ -181,7 +185,7 @@ namespace CmsWeb.Areas.Org.Models
             {
                 if (!HttpContext.Current.User.IsInRole("OrgLeadersOnly"))
                     return true;
-
+ 
                 var typeName = OrgMain.OrganizationType.ToString().Replace(" ", "");
                 return !DbUtil.Db.Setting($"UX-HideMeetingsTabForOrgLeaders-{typeName}");
             }

--- a/CmsWeb/Areas/Org/Models/Org/OrganizationModel.cs
+++ b/CmsWeb/Areas/Org/Models/Org/OrganizationModel.cs
@@ -173,7 +173,6 @@ namespace CmsWeb.Areas.Org.Models
         public bool ShowBlueToolbarExports => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarExportMenu, true);
         public bool ShowBlueToolbarCustomReports => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarCustomReportsMenu, true);
         public bool ShowBlueToolbarAdminGear => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarAdminGearMenu, true);
-        public bool ShowBlueToolbarSubGroupManagement => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarSubGroupManagement, true);
         public bool ShowBlueToolbarMembersOnlyPage => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarMembersOnlyPage, true);
         public bool ShowBlueToolbarVolunteerCalendar => RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbarVolunteerCalendar, true);
         

--- a/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
@@ -29,7 +29,10 @@
     <div class="col-md-9">
         <div class="box box-responsive">
             <div class="box-content">
-                @Html.Partial("Toolbar/Toolbar")
+                @if (Model.ShowBlueToolbar)
+                {
+                    @Html.Partial("Toolbar/Toolbar")
+                }
                 @Html.Hidden("meetingid", Model.meeting.MeetingId)
                 @Html.Hidden("sort", "false")
                 @Html.Hidden("RegularMeetingHeadCount", RegularMeetingHeadCount)
@@ -68,7 +71,14 @@
                                 <dd>
                                     @if (User.IsInRole("Attendance"))
                                     {
-                                        <a id="d-@Model.meeting.MeetingId" class="clickEdit" data-pk="d-@Model.meeting.MeetingId" data-title="Description" style="cursor: pointer">@Model.meeting.Description</a>
+                                        if (Model.AllowEditDescription)
+                                        {
+                                            <a id="d-@Model.meeting.MeetingId" class="clickEdit" data-pk="d-@Model.meeting.MeetingId" data-title="Description" style="cursor: pointer">@Model.meeting.Description</a>
+                                        }
+                                        else
+                                        {
+                                            @Model.meeting.Description
+                                        }
                                     }
                                     else
                                     {
@@ -81,41 +91,57 @@
                 </div>
                 <div class="well">
                     <div class="row">
-                        <div class="col-sm-6">
-                            <label class="control-label">Show</label>
-                            <div class="form-group" id="showbuttons">
-                                <label class="radio-inline">
-                                    <input type="radio" id="showall" name="show" value="all" /> All
-                                </label>
-                                <label class="radio-inline">
-                                    <input type="radio" id="showattends" name="show" value="attends" checked="checked" /> Attends
-                                </label>
-                                <label class="radio-inline">
-                                    <input type="radio" id="showabsents" name="show" value="absents" /> Absents
-                                </label>
-                                <label class="radio-inline">
-                                    <input type="radio" id="showreg" name="show" value="reg" /> Registered
-                                </label>
+                        @if (Model.ShowShowBox)
+                        {
+                            <div class="col-sm-6">
+                                <label class="control-label">Show</label>
+                                <div class="form-group" id="showbuttons">
+                                    <label class="radio-inline">
+                                        <input type="radio" id="showall" name="show" value="all"/> All
+                                    </label>
+                                    @if (Model.ShowAttendType)
+                                    {
+                                        <label class="radio-inline">
+                                            <input type="radio" id="showattends" name="show" value="attends" checked="checked"/> Attends
+                                        </label>
+                                    }
+                                    <label class="radio-inline">
+                                        <input type="radio" id="showabsents" name="show" value="absents"/> Absents
+                                    </label>
+                                    <label class="radio-inline">
+                                        <input type="radio" id="showreg" name="show" value="reg"/> Registered
+                                    </label>
+                                </div>
                             </div>
-                        </div>
-                        @if (User.IsInRole("Attendance"))
+                        }
+                        @if (User.IsInRole("Attendance") && Model.ShowEnableBox)
                         {
                             <div class="col-sm-6">
                                 <label class="control-label">Enable</label>
                                 <div class="form-group">
+                                    @if (Model.EnableEditByDefault)
+                                    {
+                                        Model.showall = true;
+                                    }
                                     <label class="checkbox-inline">
                                         @Html.CheckBox("editing", Model.showall) Editing
                                     </label>
                                     <label class="checkbox-inline">
                                         @Html.CheckBox("registering", Model.showregister) Register
                                     </label>
-                                    <label class="checkbox-inline">
-                                        @Html.CheckBox("currmembers", Model.currmembers) Current Members
-                                    </label>
+                                    @if (Model.ShowCurrentMemberType)
+                                    {
+                                        <label class="checkbox-inline">
+                                            @Html.CheckBox("currmembers", Model.currmembers) Current Members
+                                        </label>
+                                    }
                                 </div>
                                 <div class="pull-right">
                                     <a href="/SearchAdd2/Dialog/registered/@Model.meeting.MeetingId" class="btn btn-success hidden searchadd"><i class="fa fa-plus-circle"></i> Add Registered</a>
-                                    <a href="/SearchAdd2/Dialog/visitor/@Model.meeting.MeetingId" class="btn btn-success searchadd" title="Click to Add Guests to Meeting"><i class="fa fa-plus-circle"></i> Add Guests</a>
+                                    @if (Model.ShowAddGuest)
+                                    {
+                                        <a href="/SearchAdd2/Dialog/visitor/@Model.meeting.MeetingId" class="btn btn-success searchadd" title="Click to Add Guests to Meeting"><i class="fa fa-plus-circle"></i> Add Guests</a>
+                                    }
                                 </div>
                             </div>
                         }
@@ -135,33 +161,40 @@
                     <div class="table-responsive">
                         <table id="attends" class="table table-striped">
                             <thead>
-                                <tr>
-                                    <th class="text-center">Attended</th>
-                                    <th class="showreg" style="display: none">Commitment</th>
-                                    <th><a href="#" id="sortbyname">Name</a></th>
-                                    <th>Current Member Type</th>
-                                    <th>Attend Member Type</th>
-                                    <th>Attend Type</th>
-                                    <th>Other Attend</th>
-                                </tr>
+                            <tr>
+                                <th class="text-center">Attended</th>
+                                <th class="showreg" style="display: none">Commitment</th>
+                                <th><a href="#" id="sortbyname">Name</a></th>
+                                <th>Current Member Type</th>
+                                <th>Attend Member Type</th>
+                                <th>Attend Type</th>
+                                <th>Other Attend</th>
+                            </tr>
                             </thead>
                             <tbody>
-                                @foreach (var a in Model.Attends())
-                                {
-                                    <tr rowtype="@a.Member" @(!a.Member ? "class=info" : "")>
-                                        <td class="text-center">
-                                            <input type="checkbox" pid="@a.PeopleId" @(a.Attended ? "checked=checked" : "") class="atck" onclick="return false" onkeydown="return false" />
-                                        </td>
-                                        <td class="showreg" style="display: none">
-                                            <span id="c@(Model.meeting.MeetingId)_@(a.PeopleId)" class="clickSelect rgck commitment" data-value="@a.Commitment" data-pk="c@(Model.meeting.MeetingId)_@(a.PeopleId)" data-title="Commitment">@a.Commitment</span>
-                                        </td>
+                            @foreach (var a in Model.Attends())
+                            {
+                                <tr rowtype="@a.Member" @(!a.Member ? "class=info" : "")>
+                                    <td class="text-center">
+                                        <input type="checkbox" pid="@a.PeopleId" @(a.Attended ? "checked=checked" : "") class="atck" onclick="return false" onkeydown="return false"/>
+                                    </td>
+                                    <td class="showreg" style="display: none">
+                                        <span id="c@(Model.meeting.MeetingId)_@(a.PeopleId)" class="clickSelect rgck commitment" data-value="@a.Commitment" data-pk="c@(Model.meeting.MeetingId)_@(a.PeopleId)" data-title="Commitment">@a.Commitment</span>
+                                    </td>
+                                    @if (Model.HyperlinkNames)
+                                    {
                                         <td class="name @(a.Conflict ? "alert-danger" : "")"><a href="/Person2/@a.PeopleId" title="@a.Age">@a.Name</a></td>
-                                        <td>@a.CurrMemberType</td>
-                                        <td>@a.MemberType</td>
-                                        <td>@a.AttendType</td>
-                                        <td>@a.OtherAttend</td>
-                                    </tr>
-                                }
+                                    }
+                                    else
+                                    {
+                                        <td class="name @(a.Conflict ? "alert-danger" : "")">@a.Name</td>
+                                    }
+                                    <td>@a.CurrMemberType</td>
+                                    <td>@a.MemberType</td>
+                                    <td>@a.AttendType</td>
+                                    <td>@a.OtherAttend</td>
+                                </tr>
+                            }
                             </tbody>
                         </table>
                     </div>
@@ -213,15 +246,23 @@
                             <td class="text-right" id="NumRepeatVst"><span>@Model.meeting.NumRepeatVst</span></td>
                         </tr>
                         <tr>
-                            <td class="text-right">Other Attends:</td>
-                            <td class="text-right" id="NumOtherAttends"><span>@Model.meeting.NumOtherAttends</span></td>
+                            @if (Model.ShowOtherAttend)
+                            {
+                                <td class="text-right">Other Attends:</td>
+                                <td class="text-right" id="NumOtherAttends"><span>@Model.meeting.NumOtherAttends</span></td>
+                            }
+                            else
+                            {
+                                <td></td>
+                                <td></td>
+                            }
                             <td class="text-right">Visiting Members:</td>
                             <td class="text-right" id="NumVstMembers"><span>@Model.meeting.NumVstMembers</span></td>
                         </tr>
                     </tbody>
                 </table>
             </div>
-            @if (User.IsInRole("Attendance"))
+            @if (User.IsInRole("Attendance") && Model.ShowWandTargetBox)
             {
                 <div class="box-content">
                     <label class="sr-only" for="wandtarget">Wand Target</label>
@@ -229,7 +270,7 @@
                 </div>
             }
         </div>
-        @if (User.IsInRole("Edit"))
+        @if (User.IsInRole("Edit") && Model.ShowExtraValuesBox)
         {
             <div class="box box-primary" style="background-color: #fff;">
                 <div class="box-title">

--- a/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
@@ -99,12 +99,9 @@
                                     <label class="radio-inline">
                                         <input type="radio" id="showall" name="show" value="all"/> All
                                     </label>
-                                    @if (Model.ShowAttendType)
-                                    {
-                                        <label class="radio-inline">
-                                            <input type="radio" id="showattends" name="show" value="attends" checked="checked"/> Attends
-                                        </label>
-                                    }
+                                    <label class="radio-inline">
+                                        <input type="radio" id="showattends" name="show" value="attends" checked="checked"/> Attends
+                                    </label>
                                     <label class="radio-inline">
                                         <input type="radio" id="showabsents" name="show" value="absents"/> Absents
                                     </label>
@@ -129,12 +126,9 @@
                                     <label class="checkbox-inline">
                                         @Html.CheckBox("registering", Model.showregister) Register
                                     </label>
-                                    @if (Model.ShowCurrentMemberType)
-                                    {
-                                        <label class="checkbox-inline">
-                                            @Html.CheckBox("currmembers", Model.currmembers) Current Members
-                                        </label>
-                                    }
+                                    <label class="checkbox-inline">
+                                        @Html.CheckBox("currmembers", Model.currmembers) Current Members
+                                    </label>
                                 </div>
                                 <div class="pull-right">
                                     <a href="/SearchAdd2/Dialog/registered/@Model.meeting.MeetingId" class="btn btn-success hidden searchadd"><i class="fa fa-plus-circle"></i> Add Registered</a>
@@ -165,10 +159,19 @@
                                 <th class="text-center">Attended</th>
                                 <th class="showreg" style="display: none">Commitment</th>
                                 <th><a href="#" id="sortbyname">Name</a></th>
-                                <th>Current Member Type</th>
+                                @if (Model.ShowCurrentMemberType)
+                                {
+                                    <th>Current Member Type</th>
+                                }
                                 <th>Attend Member Type</th>
-                                <th>Attend Type</th>
-                                <th>Other Attend</th>
+                                @if (Model.ShowAttendType)
+                                {
+                                    <th>Attend Type</th>
+                                }
+                                @if (Model.ShowOtherAttend)
+                                {
+                                    <th>Other Attend</th>
+                                }
                             </tr>
                             </thead>
                             <tbody>
@@ -189,10 +192,19 @@
                                     {
                                         <td class="name @(a.Conflict ? "alert-danger" : "")">@a.Name</td>
                                     }
-                                    <td>@a.CurrMemberType</td>
+                                    @if (Model.ShowCurrentMemberType)
+                                    {
+                                        <td>@a.CurrMemberType</td>
+                                    }
                                     <td>@a.MemberType</td>
-                                    <td>@a.AttendType</td>
-                                    <td>@a.OtherAttend</td>
+                                    @if (Model.ShowAttendType)
+                                    {
+                                        <td>@a.AttendType</td>
+                                    }
+                                    @if (Model.ShowOtherAttend)
+                                    {
+                                        <td>@a.OtherAttend</td>
+                                    }
                                 </tr>
                             }
                             </tbody>

--- a/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Reports.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Reports.cshtml
@@ -1,57 +1,60 @@
 ﻿<ul class="dropdown-menu dropdown-menu-large dropdown-menu-right container bluebar-menu-col-1">
-  <li class="col-sm-12">
-    <ul>
-      <li class="dropdown-header">Reports</li>
-      @if (Model.meeting.MeetingDate >= DateTime.Today)
-      {
-          <li>
-            <a href="/Reports/RollsheetForMeeting/@Model.meeting.MeetingId" target="_blank">
-              <span class="org-context">Rollsheet Report</span>
-            </a>
-          </li>
-      }
-      <li>
-        <a href="/Reports/PastAttendee/@Model.meeting.OrganizationId" target="_blank">
-          <span class="org-context">Recent Attendance Report</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Reports/Attendee/@Model.meeting.MeetingId" target="_blank">
-          <span class="org-context">Attendee Report</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Reports/VisitsAbsents/@Model.meeting.MeetingId" target="_blank">
-          <span class="org-context">Guests/Absentees Report</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Reports/VisitsAbsents2/@Model.meeting.MeetingId" id="contactreport" target="_blank">
-          <span class="org-context">Guests/Absentees Contact Report</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Meeting/AttendanceByGroups/@Model.meeting.MeetingId" target="_blank">
-          <span class="org-context">Attendance By Groups</span>
-        </a>
-      </li>
+    <li class="col-sm-12">
+        <ul>
+            <li class="dropdown-header">Reports</li>
+            @if (Model.meeting.MeetingDate >= DateTime.Today && Model.ShowBlueToolbarRollsheet)
+            {
+                <li>
+                    <a href="/Reports/RollsheetForMeeting/@Model.meeting.MeetingId" target="_blank">
+                        <span class="org-context">Rollsheet Report</span>
+                    </a>
+                </li>
+            }
+            <li>
+                <a href="/Reports/PastAttendee/@Model.meeting.OrganizationId" target="_blank">
+                    <span class="org-context">Recent Attendance Report</span>
+                </a>
+            </li>
+            <li>
+                <a href="/Reports/Attendee/@Model.meeting.MeetingId" target="_blank">
+                    <span class="org-context">Attendee Report</span>
+                </a>
+            </li>
+            <li>
+                <a href="/Reports/VisitsAbsents/@Model.meeting.MeetingId" target="_blank">
+                    <span class="org-context">Guests/Absentees Report</span>
+                </a>
+            </li>
+            <li>
+                <a href="/Reports/VisitsAbsents2/@Model.meeting.MeetingId" id="contactreport" target="_blank">
+                    <span class="org-context">Guests/Absentees Contact Report</span>
+                </a>
+            </li>
+            <li>
+                <a href="/Meeting/AttendanceByGroups/@Model.meeting.MeetingId" target="_blank">
+                    <span class="org-context">Attendance By Groups</span>
+                </a>
+            </li>
 
-      <li class="dropdown-header">Special Pages</li>
-      <li>
-        <a href="/Meeting/iPad/@Model.meeting.MeetingId">
-          <span class="org-context">iPad Attendance</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Meeting/iPad/@Model.meeting.MeetingId?commitsOnly=true">
-          <span class="org-context">iPad Attendance Registered Only</span>
-        </a>
-      </li>
-      <li>
-        <a href="/Meeting/tickets/@Model.meeting.MeetingId">
-          <span class="org-context">Ticketing Attendance</span>
-        </a>
-      </li>
-    </ul>
-  </li>
+            <li class="dropdown-header">Special Pages</li>
+            @if (Model.ShowBlueToolbarIpadAttendance)
+            {
+                <li>
+                    <a href="/Meeting/iPad/@Model.meeting.MeetingId">
+                        <span class="org-context">iPad Attendance</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/Meeting/iPad/@Model.meeting.MeetingId?commitsOnly=true">
+                        <span class="org-context">iPad Attendance Registered Only</span>
+                    </a>
+                </li>
+            }
+            <li>
+                <a href="/Meeting/tickets/@Model.meeting.MeetingId">
+                    <span class="org-context">Ticketing Attendance</span>
+                </a>
+            </li>
+        </ul>
+    </li>
 </ul>

--- a/CmsWeb/Areas/Org/Views/Org/CommunityGroup/CommunityGroup.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/CommunityGroup/CommunityGroup.cshtml
@@ -1,5 +1,6 @@
 ﻿@model CmsWeb.Areas.Org.Models.OrganizationModel
 @using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Models.ExtraValues
 @{
     var evmodel = new ExtraValueModel(Model.Org.OrganizationId, "Organization", "CommunityGroup");
@@ -53,9 +54,8 @@
     @helper ExtraDataFormAction(ExtraValueModel evmodel, bool xs = false)
     {
         var canAddExtraValues = User.IsInRole("Admin") ||
-            (User.IsInRole("OrgLeadersOnly")
-            && DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs")
-            && !DbUtil.Db.Setting("UX-HideExtraValueEditForOrgLeaderOnly"));
+            (RoleChecker.HasSetting(SettingName.CanEditCGInfoEVs, false)
+            && !RoleChecker.HasSetting(SettingName.HideExtraValueEdit, true));
 
         if (xs)
         {

--- a/CmsWeb/Areas/Org/Views/Org/Index.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Index.cshtml
@@ -63,7 +63,10 @@
   <div class="col-lg-10">
     <div class="box box-responsive">
       <div class="box-content">
-        @Html.Partial("Toolbar/Toolbar")
+        @if (Model.ShowBlueToolbar)
+        {
+            @Html.Partial("Toolbar/Toolbar")
+        }
         @Html.Partial("Settings/Main", Model.OrgMain)
         <ul class="nav nav-tabs" id="organization-tabs">
           <li class="active"><a href="#Members-tab" aria-controls="Members-tab" class="ajax" data-toggle="tab">People</a></li>

--- a/CmsWeb/Areas/Org/Views/Org/Meetings.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Meetings.cshtml
@@ -41,7 +41,7 @@
                                 <td>@m.Location</td>
                                 <td>@m.Description</td>
                                 <td style="width: 50px;">
-                                    @if (User.IsInRole("Attendance"))
+                                    @if (User.IsInRole("Attendance") && Model.ShowDeleteMeeting)
                                     {
                                         <a href="/DeleteMeeting/@m.MeetingId" class="longrunop btn btn-danger btn-sm"><i class="fa fa-trash"></i> Delete</a>
                                     }
@@ -61,7 +61,7 @@
 </form>
 @helper FormAction(bool xs = false)
 {
-    if (User.IsInRole("Attendance"))
+    if (User.IsInRole("Attendance") && Model.ShowCreateNewMeeting)
     {
         if (xs)
         {

--- a/CmsWeb/Areas/Org/Views/Org/People.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/People.cshtml
@@ -5,14 +5,14 @@
         <div class="col-sm-12">
             <div id="groupSelector" class="btn-group">
                 @Html.Partial("People/GroupButtons", Model)
-                @if (!Model.HideOptionsButton)
+                @if (Model.ShowOptions)
                 {
                     @Html.Partial("People/GroupOptions", Model)
                 }
             </div>
         </div>
     </div>
-    @if (Model.HideFilterOptions)
+    @if (!Model.ShowSubgroupFilters)
     {
         <div style="display: none">
             @Html.Partial("People/FilterPeople", Model)

--- a/CmsWeb/Areas/Org/Views/Org/People/GroupOptions.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/People/GroupOptions.cshtml
@@ -1,8 +1,5 @@
 ﻿@using CmsData
 @model CmsWeb.Areas.Org.Models.OrgPeopleModel
-@{
-    var disablePersonLinks = DbUtil.Db.Setting("UX-DisablePersonLinksForOrgLeaders");
-}
 <div class="btn-group">
   <button data-toggle="dropdown" class="btn dropdown-toggle btn-info">
     @Model.GroupOptions
@@ -15,7 +12,7 @@
       <li class="@Model.ShowHiddenActive">
           <a id="showhide" href="#" class="grp2 @Model.ShowHiddenActive">Show Hidden</a>
       </li>
-      @if (!disablePersonLinks)
+      @if (Model.DisablePeopleLink)
       {
           <li class="@Model.ShowMinistryInfoActive">
               <a id="ministryinfo" href="#" class="grp2 @Model.ShowMinistryInfoActive">Ministry Info</a>

--- a/CmsWeb/Areas/Org/Views/Org/People/Table.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/People/Table.cshtml
@@ -5,7 +5,6 @@
 @model CmsWeb.Areas.Org.Models.OrgPeopleModel
 @{
   var target = Util2.TargetLinkPeople ? "target='people'" : "";
-  var hideBirthDate = DbUtil.Db.Setting("HideBirthDateForOrgLeaders") && Util.IsInRole("OrgLeadersOnly");
 }
 <table class="table table-striped">
   <thead>
@@ -25,11 +24,11 @@
       @Model.SortLink("MemberType")
     </th>
     <th>
-      @Model.SortLink("Church")<br/>
-      @if (!hideBirthDate)
-      {
-        <text>@Model.SortLink("Age") - @Model.SortLink("Bday")</text>
-      }
+        @Model.SortLink("Church")<br />
+        @if (Model.ShowBirthday)
+        {
+            <text>@Model.SortLink("Age") - @Model.SortLink("Bday")</text>
+        }
     </th>
     <th>Communication</th>
     <th>@Model.SortLink("% Att.")</th>
@@ -54,7 +53,7 @@
         </ul>
       </div>
     </th>
-    @if (!Model.OrgLeaderAddDrop)
+    @if (!Model.OrgLeaderAddDrop && Model.ShowTagButtons)
     {
       <th>Tag</th>
     }
@@ -80,7 +79,7 @@
         <td>@p.Tab</td>
       }
       <td>
-        @if (Model.ShowPeopleLink)
+        @if (!Model.DisablePeopleLink)
         {
           <text>@p.Name</text>
         }
@@ -108,7 +107,7 @@
       </td>
       <td>
         @p.MemberStatus<br/>
-        @if (!hideBirthDate)
+        @if (Model.ShowBirthday)
         {
           <text>@p.Age - @p.BirthDate</text>
         }
@@ -137,7 +136,7 @@
           @ShowDateLink(p.TaskDelegatedDt, "/Person2", p.PeopleId, "Has Task", "#tab-tasksassigned")
         }
       </td>
-      @if (!Model.OrgLeaderAddDrop)
+      @if (!Model.OrgLeaderAddDrop && Model.ShowTagButtons)
       {
         <td>
           <a href="#" class="taguntag btn btn-sm @(hastag ? "btn-default" : "btn-success")" title="Add to/Remove from Active Tag" pid="@p.PeopleId">
@@ -240,7 +239,7 @@
 {
   if (p.GroupCode == GroupSelectCode.Prospect)
   {
-    if (!Model.HideFilterOptions)
+    if (Model.ShowSubgroupFilters)
     {
       if (p.Hidden == true)
       {

--- a/CmsWeb/Areas/Org/Views/Org/People/Table.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/People/Table.cshtml
@@ -79,7 +79,7 @@
         <td>@p.Tab</td>
       }
       <td>
-        @if (!Model.DisablePeopleLink)
+        @if (Model.DisablePeopleLink)
         {
           <text>@p.Name</text>
         }

--- a/CmsWeb/Areas/Org/Views/Org/Settings/Main.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Settings/Main.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Areas.Org.Models
 @using UtilityExtensions
 @model OrgMain
@@ -26,7 +27,7 @@
             <div class="col-sm-3 col-md-4 col-lg-4">
                 @Html.DisplayFor(m => m.OrganizationStatus)
             </div>
-            @if (DbUtil.Db.Setting("UX-ShowParentOrgInDetails"))
+            @if (RoleChecker.HasSetting(SettingName.ShowParentOrgInDetails, false))
             {
                 <div class="col-sm-4 col-md-4 col-lg-4">
                     <dl>

--- a/CmsWeb/Areas/Org/Views/Org/Settings/Main.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Settings/Main.cshtml
@@ -1,5 +1,4 @@
 ﻿@using CmsData
-@using CmsData.Classes.RoleChecker
 @using CmsWeb.Areas.Org.Models
 @using UtilityExtensions
 @model OrgMain
@@ -27,7 +26,7 @@
             <div class="col-sm-3 col-md-4 col-lg-4">
                 @Html.DisplayFor(m => m.OrganizationStatus)
             </div>
-            @if (RoleChecker.HasSetting(SettingName.ShowParentOrgInDetails, false))
+            @if (DbUtil.Db.Setting("UX-ShowParentOrgInDetails"))
             {
                 <div class="col-sm-4 col-md-4 col-lg-4">
                     <dl>

--- a/CmsWeb/Areas/Org/Views/Org/Settings/MainEdit.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Settings/MainEdit.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @model CmsWeb.Areas.Org.Models.OrgMain
 <form class="ajax">
     <div class="well">
@@ -19,7 +20,7 @@
             <div class="col-sm-4 col-md-3 col-lg-3">
                 @Html.EditorFor(m => m.OrganizationStatus)
             </div>
-            @if (DbUtil.Db.Setting("UX-ShowParentOrgInDetails"))
+            @if (RoleChecker.HasSetting(SettingName.ShowParentOrgInDetails, false))
             {
                 <div class="col-sm-4 col-md-3 col-lg-3">
                     <label class="control-label">Parent Organization</label>

--- a/CmsWeb/Areas/Org/Views/Org/Settings/MainEdit.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Settings/MainEdit.cshtml
@@ -1,5 +1,4 @@
 ﻿@using CmsData
-@using CmsData.Classes.RoleChecker
 @model CmsWeb.Areas.Org.Models.OrgMain
 <form class="ajax">
     <div class="well">
@@ -20,7 +19,7 @@
             <div class="col-sm-4 col-md-3 col-lg-3">
                 @Html.EditorFor(m => m.OrganizationStatus)
             </div>
-            @if (RoleChecker.HasSetting(SettingName.ShowParentOrgInDetails, false))
+            @if (DbUtil.Db.Setting("UX-ShowParentOrgInDetails"))
             {
                 <div class="col-sm-4 col-md-3 col-lg-3">
                     <label class="control-label">Parent Organization</label>

--- a/CmsWeb/Areas/Org/Views/Org/Toolbar/Email.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Toolbar/Email.cshtml
@@ -10,12 +10,11 @@
     var o = model.Org;
     var edit = User.IsInRole("Edit");
     var qb = DbUtil.Db.QueryIsCurrentUser();
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
 }
 <ul class="dropdown-menu dropdown-menu-large dropdown-menu-right container bluebar-menu-col-1">
     <li class="col-sm-12">
         <ul>
-            @if (showAdvanced)
+            @if (Model.ShowBlueToolbarFullEmail)
             {
                 <li class="dropdown-header">Email</li>
                 <li><a href='/Email/@ViewBag.queryid' class="qid">Individuals</a></li>
@@ -56,9 +55,18 @@
             else
             {
                 <li class="dropdown-header">Email</li>
-                <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid' class="qid">Email Members</a></li>
-                <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid&onlyProspects=true' class="qid">Email Prospects</a></li>
-                <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid&membersAndProspects=true' class="qid">Email Members & Prospects</a></li>
+                if (Model.ShowBlueToolbarEmailMembers)
+                {
+                    <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid' class="qid">Email Members</a></li>
+                }
+                if (Model.ShowBlueToolbarEmailProspects)
+                {
+                    <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid&onlyProspects=true' class="qid">Email Prospects</a></li>
+                }
+                if (Model.ShowBlueToolbarEmailMembersAndProspects)
+                {
+                    <li><a href='/Email/@ViewBag.queryid?templateID=0&orgid=@oid&membersAndProspects=true' class="qid">Email Members & Prospects</a></li>
+                }
             }
         </ul>
     </li>

--- a/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsData.Codes
 @using CmsWeb.Areas.Org.Models
 @{
@@ -10,7 +11,7 @@
     var oid = ViewBag.oid;
     var model = (OrganizationModel)ViewBag.model;
     var o = model.Org;
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+    var showAdvanced = RoleChecker.HasSetting(SettingName.LimitToolbar, false);
 }
 
 @if (showAdvanced)
@@ -19,14 +20,17 @@
         <li class="col-sm-6">
             <ul id="ultoolbar">
                 <li class="dropdown-header">Administrative</li>
-                @if (admin || manager)
+                @if (admin || manager || model.ShowBlueToolbarSubGroupManagement)
                 {
                     <li><a href="/OrgGroups/@oid"><span class="org-context">Sub-Group Management</span></a></li>
                     <li class="hideAlt"><a href="/RegSettings/@oid"><span class="org-context">View Registration Document</span></a></li>
                 }
-                <li><a href="/OrgContent/@oid" target="_blank"><span class="org-context">Members Only Page</span></a></li>
+                @if (model.ShowBlueToolbarMembersOnlyPage)
+                {
+                    <li><a href="/OrgContent/@oid" target="_blank"><span class="org-context">Members Only Page</span></a></li>
+                }
                 <li><a id="tryreg" href="#TryRegDialog" data-toggle="modal"><span class="org-context">Try Registration</span></a></li>
-                @if (model.IsVolunteerLeader && o.RegistrationTypeId == RegistrationTypeCode.ChooseVolunteerTimes)
+                @if (model.IsVolunteerLeader && o.RegistrationTypeId == RegistrationTypeCode.ChooseVolunteerTimes && model.ShowBlueToolbarVolunteerCalendar)
                 {
                     <li><a id="VolunteerCalendar" href="/Volunteers/Calendar/@oid" target="calendar"><span class="org-context">Volunteer Calendar</span></a></li>
                 }
@@ -69,7 +73,7 @@ else
             <ul>
                 <li class="dropdown-header">Content</li>
                 <li><a href="/OrgContent/@o.OrganizationId" class="qid">Members Only Page</a></li>
-                @if (model.IsVolunteerLeader && o.RegistrationTypeId == RegistrationTypeCode.ChooseVolunteerTimes)
+                @if (model.IsVolunteerLeader && o.RegistrationTypeId == RegistrationTypeCode.ChooseVolunteerTimes && model.ShowBlueToolbarVolunteerCalendar)
                 {
                     <li><a id="VolunteerCalendar" href="/Volunteers/Calendar/@oid" target="calendar"><span class="org-context">Volunteer Calendar</span></a></li>
                 }

--- a/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
@@ -11,7 +11,7 @@
     var oid = ViewBag.oid;
     var model = (OrganizationModel)ViewBag.model;
     var o = model.Org;
-    var showAdvanced = RoleChecker.HasSetting(SettingName.LimitToolbar, false);
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
 }
 
 @if (showAdvanced)

--- a/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Toolbar/Gear.cshtml
@@ -20,7 +20,7 @@
         <li class="col-sm-6">
             <ul id="ultoolbar">
                 <li class="dropdown-header">Administrative</li>
-                @if (admin || manager || model.ShowBlueToolbarSubGroupManagement)
+                @if (admin || manager)
                 {
                     <li><a href="/OrgGroups/@oid"><span class="org-context">Sub-Group Management</span></a></li>
                     <li class="hideAlt"><a href="/RegSettings/@oid"><span class="org-context">View Registration Document</span></a></li>

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
@@ -7,7 +7,6 @@ using CmsData;
 using CmsWeb.Models;
 using MoreLinq;
 using UtilityExtensions;
-using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.People.Models
 {
@@ -147,7 +146,7 @@ namespace CmsWeb.Areas.People.Models
                        IsLeaderAttendanceType = (om.MemberType.AttendanceTypeId ?? 0) == 10
                    };
 
-            if (RoleChecker.HasSetting(SettingName.ShowChildOrgsOnInvolvementTabs, false))
+            if (DbUtil.Db.Setting("UX-ShowChildOrgsOnInvolvementTabs"))
             {
                 var viewListAsList = viewList.ToList();
                 var parentIds = viewListAsList.Select(x => x.OrgId).ToList();

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
@@ -7,6 +7,7 @@ using CmsData;
 using CmsWeb.Models;
 using MoreLinq;
 using UtilityExtensions;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.People.Models
 {
@@ -146,7 +147,7 @@ namespace CmsWeb.Areas.People.Models
                        IsLeaderAttendanceType = (om.MemberType.AttendanceTypeId ?? 0) == 10
                    };
 
-            if (DbUtil.Db.Setting("UX-ShowChildOrgsOnInvolvementTabs"))
+            if (RoleChecker.HasSetting(SettingName.ShowChildOrgsOnInvolvementTabs, false))
             {
                 var viewListAsList = viewList.ToList();
                 var parentIds = viewListAsList.Select(x => x.OrgId).ToList();

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using CmsData;
+using CmsData.Classes.RoleChecker;
 using UtilityExtensions;
 
 namespace CmsWeb.Areas.People.Models
@@ -44,7 +45,7 @@ namespace CmsWeb.Areas.People.Models
                 case "name":
                 case "organization":
                     if (inAccessRole &&
-                        (IsLeaderAttendanceType || !inOrgLeadersOnlyRole || !DbUtil.Db.Setting("UX-OrgLeadersOtherGroupsContentOnly")))
+                        (IsLeaderAttendanceType || !inOrgLeadersOnlyRole || !RoleChecker.HasSetting(SettingName.OtherGroupsContentOnly, false)))
                     {
                         return $"<a href=\"/Org/{OrgId}\">{Name}</a>";
                     }
@@ -71,7 +72,7 @@ namespace CmsWeb.Areas.People.Models
                 case "schedule":
                     return Schedule;
                 case "leader":
-                    if (inAccessRole && !(inOrgLeadersOnlyRole && DbUtil.Db.Setting("UX-OrgLeadersOtherGroupsContentOnly")))
+                    if (inAccessRole && !RoleChecker.HasSetting(SettingName.OtherGroupsContentOnly, false))
                     {
                         return $"<a href=\" /Person2/{LeaderId}\">{LeaderName}</a>";
                     }

--- a/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Emails/Emails.cshtml
@@ -1,5 +1,6 @@
 ﻿@model CmsWeb.Areas.People.Models.EmailModel
 @using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Areas.People.Models
 @using UtilityExtensions
 @{
@@ -7,7 +8,7 @@
     var showEmailDetails = false;
     if (User.IsInRole("OrgLeadersOnly"))
     {
-        showEmailDetails = !DbUtil.Db.Setting("UX-HideEmailDetailsForOrgLeaders", false);
+        showEmailDetails = !RoleChecker.HasSetting(SettingName.HideEmailDetails, false);
     }
     else if (User.IsInRole("Access"))
     {

--- a/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Areas.People.Models
 @using UtilityExtensions
 @model FamilyModel
@@ -6,7 +7,7 @@
     var showFamilyQueryLink = false;
     if (User.IsInRole("OrgLeadersOnly"))
     {
-        showFamilyQueryLink = !DbUtil.Db.Setting("UX-HideQueriesForOrgLeaders", false);
+        showFamilyQueryLink = !RoleChecker.HasSetting(SettingName.HideQueries, false);
     }
     else if (User.IsInRole("Access"))
     {

--- a/CmsWeb/Areas/People/Views/Person/Family/Related.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Family/Related.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Areas.People.Models
 @model FamilyModel
 @{
@@ -6,7 +7,7 @@
     var showFamilyQueryLink = false;
     if (User.IsInRole("OrgLeadersOnly"))
     {
-        showFamilyQueryLink = !DbUtil.Db.Setting("UX-HideQueriesForOrgLeaders", false);
+        showFamilyQueryLink = !RoleChecker.HasSetting(SettingName.HideQueries, false);
     }
     else if (User.IsInRole("Access"))
     {

--- a/CmsWeb/Areas/People/Views/Person/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @using UtilityExtensions
 @using CmsWeb.Areas.People.Models
 @model PersonModel
@@ -19,7 +20,7 @@
     var showMinistryTab = false;
     if (User.IsInRole("OrgLeadersOnly"))
     {
-        showMinistryTab = !DbUtil.Db.Setting("UX-HideMinistryTabForOrgLeaders");
+        showMinistryTab = !RoleChecker.HasSetting(SettingName.HideMinistryTab, false);
     }
     else if (User.IsInRole("Access"))
     {

--- a/CmsWeb/Areas/People/Views/Person/Toolbar/GearStandard.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Toolbar/GearStandard.cshtml
@@ -1,8 +1,9 @@
 ﻿@using CmsData
+@using CmsData.Classes.RoleChecker
 @{
     var edit = User.IsInRole("Edit");
     var developer = User.IsInRole("Developer");
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
 }
 <ul>
     @if (showAdvanced)

--- a/CmsWeb/Areas/Public/Models/OrgContentInfo.cs
+++ b/CmsWeb/Areas/Public/Models/OrgContentInfo.cs
@@ -7,6 +7,7 @@ using CmsData;
 using UtilityExtensions;
 using DbUtil = CmsData.DbUtil;
 using Image = ImageData.Image;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Models
 {
@@ -21,7 +22,7 @@ namespace CmsWeb.Models
         public bool NotAuthenticated { get; set; }
         public OrgContent oc { get; set; }
 
-        public bool CanEdit => ((Util.IsInRole("ContentEdit") || Util.IsInRole("Edit") || DbUtil.Db.Setting("UX-LeadersCanAlwaysEditOrgContent")) && IsLeader) ||  Util.IsInRole("Admin");
+        public bool CanEdit => ((Util.IsInRole("ContentEdit") || Util.IsInRole("Edit") || RoleChecker.HasSetting(SettingName.LeadersCanAlwaysEditOrgContent, false)) && IsLeader) ||  Util.IsInRole("Admin");
 
         private string html;
         public string Html

--- a/CmsWeb/Areas/Public/Views/SmallGroupFinder/Map.cshtml
+++ b/CmsWeb/Areas/Public/Views/SmallGroupFinder/Map.cshtml
@@ -19,7 +19,7 @@
 
 @if (Request.IsLocal)
 {
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&key=AIzaSyD8NYfDRQUKgB0Jra9hsYNIRoKwo4Xyvws"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&key=AIzaSyAbzQ307GkTAzchqaHZVyT4X6nI40x3Ahg"></script>
 }
 else
 {

--- a/CmsWeb/Areas/Search/Models/SearchAdd/SearchAddModel.cs
+++ b/CmsWeb/Areas/Search/Models/SearchAdd/SearchAddModel.cs
@@ -15,6 +15,7 @@ using CmsData;
 using CmsData.Codes;
 using CmsWeb.Code;
 using UtilityExtensions;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.Search.Models
 {
@@ -143,7 +144,7 @@ namespace CmsWeb.Areas.Search.Models
 
         public bool OnlyOne => onlyonetypes.Contains(AddContext.ToLower());
 
-        public new bool ShowLimitedSearch => (HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeaderLimitedSearchPerson"));
+        public new bool ShowLimitedSearch => RoleChecker.HasSetting(SettingName.LimitedSearchPerson, false);
 
         public int NewFamilyId { get; set; }
         public int? EntryPointId { get; set; }

--- a/CmsWeb/Areas/Search/Models/SearchAdd/SearchResultsModel.cs
+++ b/CmsWeb/Areas/Search/Models/SearchAdd/SearchResultsModel.cs
@@ -15,6 +15,7 @@ using CmsData;
 using CmsWeb.Models;
 using MoreLinq;
 using UtilityExtensions;
+using CmsData.Classes.RoleChecker;
 
 namespace CmsWeb.Areas.Search.Models
 {
@@ -45,7 +46,7 @@ namespace CmsWeb.Areas.Search.Models
 
         public bool UsersOnly => usersOnlyContextTypes.Contains(AddContext.ToLower());
 
-        public bool ShowLimitedSearch => (HttpContext.Current.User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-OrgLeaderLimitedSearchPerson"));
+        public bool ShowLimitedSearch => RoleChecker.HasSetting(SettingName.LimitedSearchPerson, false);
 
         public string HelpLink(string page)
         {

--- a/CmsWeb/Code/CmsController.cs
+++ b/CmsWeb/Code/CmsController.cs
@@ -7,6 +7,7 @@ using System.Web.Mvc;
 using System.Linq;
 using System.Net;
 using CmsData;
+using CmsData.Classes.RoleChecker;
 using CmsWeb.Areas.Manage.Controllers;
 using CmsWeb.Code;
 using CmsWeb.Models;
@@ -108,7 +109,7 @@ namespace CmsWeb
                     filterContext.Result = Redirect(r);
             }
 
-            var disableHomePageForOrgLeaders = DbUtil.Db.Setting("UX-DisableHomePageForOrgLeaders");
+            var disableHomePageForOrgLeaders = RoleChecker.HasSetting(SettingName.DisableHomePage, false);
             var contr = filterContext.RouteData.Values["Controller"].ToString();
             var act = filterContext.RouteData.Values["Action"].ToString();
             var orgleaderonly = User.IsInRole("OrgLeadersOnly");

--- a/CmsWeb/Views/ExtraValue/EditStandard.cshtml
+++ b/CmsWeb/Views/ExtraValue/EditStandard.cshtml
@@ -1,4 +1,5 @@
-﻿@using CmsWeb.Models.ExtraValues
+﻿@using CmsData.Classes.RoleChecker
+@using CmsWeb.Models.ExtraValues
 @model NewExtraValueModel
 <div class="modal-dialog">
     <div class="modal-content">
@@ -28,7 +29,7 @@
                     @Html.ListBox("VisibilityRolesList", new MultiSelectList(Model.VisibilitySelectedRoles(), "Value", "Text"), new { multiple = "multiple", @class = "form-control multi-select" })
                 </div>
             </div>
-            @if (DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs"))
+            @if (RoleChecker.HasSetting(SettingName.CanEditCGInfoEVs, false))
             {
                 <div class="form-group">
                     <label for="EditableRolesList" class="control-label">Editable by Roles</label>

--- a/CmsWeb/Views/ExtraValue/NewStandard.cshtml
+++ b/CmsWeb/Views/ExtraValue/NewStandard.cshtml
@@ -1,4 +1,5 @@
-﻿@using CmsWeb.Models.ExtraValues
+﻿@using CmsData.Classes.RoleChecker
+@using CmsWeb.Models.ExtraValues
 @model NewExtraValueModel
 <div class="modal-dialog">
     <div class="modal-content">
@@ -25,7 +26,7 @@
                     @Html.DropDownList("VisibilityRolesList", new SelectList(Model.VisibilitySelectedRoles(), "Value", "Text"), new { multiple = "multiple", @class = "form-control multi-select" })
                 </div>
             </div>
-            @if (DbUtil.Db.Setting("UX-OrgLeadersOnlyCanEditCGInfoEVs"))
+            @if (RoleChecker.HasSetting(SettingName.CanEditCGInfoEVs, false))
             {
                 <div class="form-group">
                     <label for="EditableRolesList" class="control-label">Editable by Roles</label>

--- a/CmsWeb/Views/Shared/NavBar.cshtml
+++ b/CmsWeb/Views/Shared/NavBar.cshtml
@@ -1,6 +1,7 @@
 ﻿@using CmsWeb.Code
+@using CmsData.Classes.RoleChecker
 @{
-    var hideNavTabs = User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-HideNavTabsForOrgLeaders");
+    var hideNavTabs = RoleChecker.HasSetting(SettingName.HideNavTabs, false);
     var access = User.IsInRole("Access");
     var customHeaderImage = CustomHeader.HeaderImage("~/Content/touchpoint/img/logo.png");
     var customSmallHeaderImage = CustomHeader.SmallHeaderImage("~/Content/touchpoint/img/logo_sm.png");

--- a/CmsWeb/Views/Shared/Toolbar/Email.cshtml
+++ b/CmsWeb/Views/Shared/Toolbar/Email.cshtml
@@ -1,8 +1,9 @@
-﻿@using CmsData.Classes.Twilio
+﻿@using CmsData.Classes.RoleChecker
+@using CmsData.Classes.Twilio
 @{
     var twilio = TwilioHelper.userSendSMS(Util.UserId);
     var qb = DbUtil.Db.QueryIsCurrentUser();
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
 }
 <ul class="dropdown-menu dropdown-menu-large dropdown-menu-right container bluebar-menu-col-1">
   <li class="col-sm-12">

--- a/CmsWeb/Views/Shared/Toolbar/Toolbar.cshtml
+++ b/CmsWeb/Views/Shared/Toolbar/Toolbar.cshtml
@@ -5,16 +5,22 @@
     var showBlueToolbarExports = true;
     var showBlueToolbarCustomReports = true;
     var showBlueToolbarAdminGear = true;
-    if (Model is OrganizationModel)
+    var showAdvanced = true;
+    if (Request?.Url?.AbsolutePath.StartsWith("/Org") == true)
     {
         showBlueToolbarExports = Model.ShowBlueToolbarExports;
         showBlueToolbarCustomReports = Model.ShowBlueToolbarCustomReports;
         showBlueToolbarAdminGear = Model.ShowBlueToolbarAdminGear;
+        showAdvanced = RoleChecker.HasSetting(SettingName.Organization_ShowBlueToolbar, true);
+    }
+    else if (Request?.Url?.AbsolutePath.StartsWith("/Person") == true)
+    {
+        showAdvanced = RoleChecker.HasSetting(SettingName.Person_ShowBlueToolbar, true);
     }
 }
 <div id="bluetoolbarstop">
     <div id="bluebar-menu" class="btn-group pull-right">
-        @if (RoleChecker.HasSetting(SettingName.Person_ShowBlueToolbar, true))
+        @if (showAdvanced)
         {
             <div class="btn-group btn-group-lg dropdown-large">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">

--- a/CmsWeb/Views/Shared/Toolbar/Toolbar.cshtml
+++ b/CmsWeb/Views/Shared/Toolbar/Toolbar.cshtml
@@ -1,9 +1,20 @@
-﻿@{
-    var showAdvanced = !(User.IsInRole("OrgLeadersOnly") && DbUtil.Db.Setting("UX-LimitToolbarForOrgLeaders"));
+﻿@using System.Activities.Expressions
+@using CmsData.Classes.RoleChecker
+@using CmsWeb.Areas.Org.Models
+@{
+    var showBlueToolbarExports = true;
+    var showBlueToolbarCustomReports = true;
+    var showBlueToolbarAdminGear = true;
+    if (Model is OrganizationModel)
+    {
+        showBlueToolbarExports = Model.ShowBlueToolbarExports;
+        showBlueToolbarCustomReports = Model.ShowBlueToolbarCustomReports;
+        showBlueToolbarAdminGear = Model.ShowBlueToolbarAdminGear;
+    }
 }
 <div id="bluetoolbarstop">
     <div id="bluebar-menu" class="btn-group pull-right">
-        @if (showAdvanced || ViewContext.Controller.GetType().Name == "OrgController")
+        @if (RoleChecker.HasSetting(SettingName.Person_ShowBlueToolbar, true))
         {
             <div class="btn-group btn-group-lg dropdown-large">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
@@ -11,30 +22,34 @@
                 </button>
                 @Html.Partial("Toolbar/Email")
             </div>
-        }
-        @if (showAdvanced)
-        {
-            <div class="btn-group btn-group-lg dropdown-large">
-                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                    <span class="fa fa-cloud-download"></span>
-                </button>
-                @Html.Partial("Toolbar/Reports")
-            </div>
-            <div class="btn-group btn-group-lg dropdown-large">
-                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                    <span class="fa fa-code"></span>
-                </button>
-                @Html.Partial("Toolbar/Custom")
-            </div>
-        }
-        @if (showAdvanced || ViewContext.Controller.GetType().Name == "OrgController")
-        {
-            <div class="btn-group btn-group-lg dropdown-large">
-                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                    <span class="fa fa-cog"></span>
-                </button>
-                @Html.Partial("Toolbar/Gear")
-            </div>
+            if (showBlueToolbarExports)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-cloud-download"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Reports")
+                </div>
+            }
+            if (showBlueToolbarCustomReports)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-code"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Custom")
+                </div>
+            }
+            if (showBlueToolbarAdminGear)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-cog"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Gear")
+                </div>
+
+            }
         }
     </div>
 </div>

--- a/CmsWeb/Views/Shared/Toolbar/ToolbarMyData.cshtml
+++ b/CmsWeb/Views/Shared/Toolbar/ToolbarMyData.cshtml
@@ -1,17 +1,21 @@
-﻿<div id="bluetoolbarstop">
+﻿@using CmsData.Classes.RoleChecker
+<div id="bluetoolbarstop">
     <div id="bluebar-menu" class="btn-group pull-right">
-        <div class="btn-group btn-group-lg" role="group">
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i></button>
-            <ul class="dropdown-menu dropdown-menu-right">
-                @Helper.LiAnchorLink("Change Password", "/Account/ChangePassword/")
-                <li class="divider"></li>
-                @Helper.LiAnchorLinkIcon("Log Out", "dropdown-icon fa fa-power-off", "/Account/LogOff/")
-            </ul>
-        </div>
-        <div class="btn-group btn-group-lg">
-            <a href="/Home/MyDataSupport" class="btn btn-primary btn-person-action">
-                <i class="fa fa-question-circle"></i>
-            </a>
-        </div>
+        @if (RoleChecker.HasSetting(SettingName.Person_ShowBlueToolbar, true))
+        {
+            <div class="btn-group btn-group-lg" role="group">
+                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user"></i></button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                    @Helper.LiAnchorLink("Change Password", "/Account/ChangePassword/")
+                    <li class="divider"></li>
+                    @Helper.LiAnchorLinkIcon("Log Out", "dropdown-icon fa fa-power-off", "/Account/LogOff/")
+                </ul>
+            </div>
+            <div class="btn-group btn-group-lg">
+                <a href="/Home/MyDataSupport" class="btn btn-primary btn-person-action">
+                    <i class="fa fa-question-circle"></i>
+                </a>
+            </div>
+        }
     </div>
 </div>


### PR DESCRIPTION
Per my earlier email, this pull request covers the clean up / refactoring from the existing admin settings over to use the new `CustomAccessRoles.xml`. The format for the file is something like:

```xml
<?xml version="1.0" encoding="utf-8"?>
<roles>
    <role name="OrgLeadersOnly">
        <settings>
            <setting name="DisableHomePage" value="true" />
            <setting name="DisablePersonLinks" value="true" />
            <setting name="HideEmailDetails" value="true" />
            <setting name="HideExtraValueEdit" value="true" />
            <setting name="HideGuestsOrgMembers" value="true" />
            <setting name="HideInactiveOrgMembers" value="true" />
            <setting name="HidePendingOrgMembers" value="true" />
            <setting name="HideMinistryTab" value="true" />
            <setting name="HideNavTabs" value="true" />
            <setting name="HideQueries" value="true" />
            <setting name="LeadersCanAlwaysEditOrgContent" value="true" />
            <setting name="LimitToolbar" value="true" />
            <setting name="LimitedSearchPerson" value="true" />
            <setting name="CanEditCGInfoEVs" value="true" />
            <setting name="EditMemberData" value="true" />
            <setting name="OrgMembersDropAdd" value="true" />
            <setting name="OtherGroupsContentOnly" value="true" />
            <setting name="Person-ShowBlueToolbar" value="false" />
            <setting name="Organization-ShowSettingsTab" value="false" />
            <setting name="Organization-ShowBlueToolbar" value="true" />
            <setting name="Organization-ShowBlueToolbarFullEmailMenu" value="false" />
            <setting name="Organization-ShowBlueToolbarEmailMembers" value="true" />
            <setting name="Organization-ShowBlueToolbarEmailProspects" value="true" />
            <setting name="Organization-ShowBlueToolbarEmailMembersAndProspects" value="true" />
            <setting name="Organization-ShowBlueToolbarExportMenu" value="false" />
            <setting name="Organization-ShowBlueToolbarCustomReportsMenu" value="false" />
            <setting name="Organization-ShowBlueToolbarAdminGearMenu" value="true" />
            <setting name="Organization-ShowBlueToolbarMembersOnlyPage" value="true" />
            <setting name="Organization-ShowBlueToolbarVolunteerCalendar" value="true" />
            <setting name="Organization-ShowAddress" value="false" />
            <setting name="Organization-ShowOptionsMenu" value="false" />
            <setting name="Organization-ShowFiltersBar" value="false" />
            <setting name="Organization-CollapseOrgDetails" value="true" />
            <setting name="Organization-ShowBirthday" value="false" />
            <setting name="Organization-ShowAddress" value="false" />
            <setting name="Organization-ShowCreateNewMeeting" value="false" />
            <setting name="Organization-ShowDeleteMeeting" value="false" />
            <setting name="Organization-ShowTagButtons" value="false" />
            <setting name="Meeting-HyperlinkNames" value="false" />
            <setting name="Meeting-ShowAddGuest" value="true" />
            <setting name="Meeting-AllowEditDescription" value="false" />
            <setting name="Meeting-ShowExtraValuesBox" value="false" />
            <setting name="Meeting-ShowWandTargetBox" value="false" />
            <setting name="Meeting-ShowBlueToolbar" value="false" />
            <setting name="Meeting-ShowBlueToolbarIpadAttendance" value="false" />
            <setting name="Meeting-ShowBlueToolbarRollsheet" value="false" />
            <setting name="Meeting-EnableEditByDefault" value="true" />
            <setting name="Meeting-ShowEnableBox" value="false" />
            <setting name="Meeting-ShowShowBox" value="false" />
            <setting name="Meeting-ShowAttendType" value="false" />
            <setting name="Meeting-ShowOtherAttend" value="false" />
            <setting name="Meeting-ShowCurrentMemberType" value="false" />
        </settings>
    </role>
</roles>
```

We also added a new C# class to help with parsing/checking the settings. Usage would be like:

```csharp
RoleChecker.HasSetting(SettingName.CanEditCGInfoEVs, false)
```

Finally, Kayan has already signed off and tested this on staging (pointed to the staging database).

Thanks!