### PR TITLE
Email prospect fix

### DIFF
--- a/CmsWeb/Areas/Main/Controllers/EmailController.cs
+++ b/CmsWeb/Areas/Main/Controllers/EmailController.cs
@@ -61,6 +61,7 @@ namespace CmsWeb.Areas.Main.Controllers
 
             var me = new MassEmailer(id, parents, ccparents, nodups);
             me.Host = Util.Host;
+            me.OnlyProspects = onlyProspects.GetValueOrDefault();
 
             // Unless UX-AllowMyDataUserEmails is true, CmsController.OnActionExecuting() will filter them
             if (!User.IsInRole("Access"))
@@ -322,6 +323,8 @@ namespace CmsWeb.Areas.Main.Controllers
                 return Json(new { error = ex.Message });
             }
 
+            var onlyProspects = m.OnlyProspects;
+
             HostingEnvironment.QueueBackgroundWorkItem(ct =>
             {
                 try
@@ -334,7 +337,7 @@ namespace CmsWeb.Areas.Main.Controllers
                     Util.UserEmail = userEmail;
                     Util.IsInRoleEmailTest = isInRoleEmailTest;
                     Util.IsMyDataUser = isMyDataUser;
-                    db.SendPeopleEmail(id);
+                    db.SendPeopleEmail(id, onlyProspects);
                 }
                 catch (Exception ex)
                 {

--- a/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
+++ b/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
@@ -29,6 +29,7 @@ namespace CmsWeb.Areas.Main.Models
         public List<string> Recipients { get; set; }
         public List<int> RecipientIds { get; set; }
         public IEnumerable<int> AdditionalRecipients { get; set; }
+        public bool OnlyProspects { get; set; }
 
         public List<MailAddress> CcAddresses = new List<MailAddress>();
         public bool recovery;

--- a/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
+++ b/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
@@ -26,7 +26,8 @@ namespace CmsWeb.Areas.Main.Models
         public string Body { get; set; }
         public DateTime? Schedule { get; set; }
         public bool PublicViewable { get; set; }
-        public IEnumerable<string> Recipients { get; set; }
+        public List<string> Recipients { get; set; }
+        public List<int> RecipientIds { get; set; }
         public IEnumerable<int> AdditionalRecipients { get; set; }
 
         public List<MailAddress> CcAddresses = new List<MailAddress>();

--- a/CmsWeb/Areas/Main/Views/Email/Index.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Index.cshtml
@@ -78,6 +78,12 @@
                                         }
                                     }
                                 </select>
+
+                                foreach (var rId in Model.RecipientIds)
+                                {
+                                    <input type="hidden" name="RecipientIds" value="@rId" />
+                                }
+
                                 if (Model.Recipients.Count() <= 500)
                                 {
                                     <p class="help-block">@Model.Count @( Model.Count != 1 ? "people" : "person")@(Model.wantParents ? " including parents." : ".")</p>

--- a/CmsWeb/Areas/Main/Views/Email/Index.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Index.cshtml
@@ -46,6 +46,7 @@
                     @Html.Hidden("wantParents", Model.wantParents)
                     @Html.Hidden("ccparents", Model.CcParents)
                     @Html.Hidden("noDuplicates", Model.noDuplicates)
+                    @Html.Hidden("OnlyProspects", Model.OnlyProspects)
                     <div class="form-group">
                         <label for="FromAddress" class="col-sm-2 control-label">From:</label>
                         <div class="col-sm-10">


### PR DESCRIPTION
A bug was found related to the "Only Prospects" email feature (and the members and prospects list). First off, there is a recipients list that is stored off in hidden fields. It also then uses a hidden field for "only prospects" so that the Emailer doesn't load all recipients up from an org and only relies on the recipient list (which populated the `EmailQueueTos` list).

This was tested on staging and signed off by Redeemer.