### PR TITLE
Attempt to fix perf issue related to member only page

### DIFF
--- a/CmsWeb/Areas/Public/Models/OrgContentInfo.cs
+++ b/CmsWeb/Areas/Public/Models/OrgContentInfo.cs
@@ -8,6 +8,7 @@ using UtilityExtensions;
 using DbUtil = CmsData.DbUtil;
 using Image = ImageData.Image;
 using CmsData.Classes.RoleChecker;
+using CmsData.Codes;
 
 namespace CmsWeb.Models
 {
@@ -139,17 +140,19 @@ namespace CmsWeb.Models
 
         public IEnumerable<MemberInfo> GetMemberList()
         {
-            var members = DbUtil.Db.OrgPeopleCurrent(OrgId);
-            foreach (var member in members)
-            {
-                var person = DbUtil.Db.LoadPersonById(member.PeopleId);
-                yield return new MemberInfo
-                {
-                    Name = person.Name,
-                    MemberType = member.MemberType,
-                    PeopleId = member.PeopleId
-                };
-            }
+            return (from om in DbUtil.Db.OrganizationMembers
+                    where om.OrganizationId == OrgId
+                    where
+                        om.MemberTypeId != MemberTypeCode.Prospect &&
+                        om.MemberTypeId != MemberTypeCode.InActive
+                    orderby om.Person.Name
+                    select new MemberInfo
+                    {
+                        Name = om.Person.Name,
+                        MemberType = om.MemberType.Description,
+                        PeopleId = om.PeopleId
+                    })
+                    .ToList();
         }
 
         public class MemberInfo


### PR DESCRIPTION
I couldn't use `CurrOrgMembers` as is because it also returns prospects and the member only page directory only needs to show members/leaders. I ended up building a LINQ query instead... it seems to perform a lot better now, though, because it is a single query instead of an N+1 issue.