### PR TITLE
Redeemer-Requested Changes

### DIFF
--- a/CmsWeb/Areas/Dialog/Controllers/AddResourceController.cs
+++ b/CmsWeb/Areas/Dialog/Controllers/AddResourceController.cs
@@ -32,6 +32,7 @@ namespace CmsWeb.Areas.Dialog.Controllers
                 CreationDate = Util.Now,
                 Description = m.Description,
                 MemberTypeIds = m.MemberTypeIds != null ? string.Join(",", m.MemberTypeIds) : string.Empty,
+                StatusFlagIds = m.StatusFlagIds != null ? string.Join(",", m.StatusFlagIds) : string.Empty,
                 DivisionId = m.DivisionId,
                 CampusId = m.CampusId,
                 Name = m.Name,

--- a/CmsWeb/Areas/Dialog/Models/ResourceModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/ResourceModel.cs
@@ -21,6 +21,7 @@ namespace CmsWeb.Areas.Dialog.Models
         public IEnumerable<int> OrganizationTypeIds { get; set; } = new List<int>();
         public int? CampusId { get; set; }
         public IEnumerable<int> MemberTypeIds { get; set; }
+        public IEnumerable<int> StatusFlagIds { get; set; }
         public string Description { get; set; }
         public int DisplayOrder { get; set; }
         public IEnumerable<FileUpload> Files { get; set; }
@@ -114,6 +115,21 @@ namespace CmsWeb.Areas.Dialog.Models
                 return list;
             }
         }
+
+        public IEnumerable<SelectListItem> StatusFlags
+        {
+            get
+            {
+                var list = DbUtil.Db.ViewStatusFlagNamesRoles.Select(x => new SelectListItem
+                {
+                    Text = x.Name,
+                    Value = x.Id.ToString()
+                }).ToList();
+
+                list.Insert(0, new SelectListItem { Value = "0", Text = "(none)", Selected = true });
+                return list;
+            }
+        }
     }
 
     public class EditResourceModel
@@ -127,6 +143,7 @@ namespace CmsWeb.Areas.Dialog.Models
         public IEnumerable<int> OrganizationTypeIds { get; set; } = new List<int>();
         public int? CampusId { get; set; }
         public IEnumerable<int> MemberTypeIds { get; set; }
+        public IEnumerable<int> StatusFlagIds { get; set; }
         public string Description { get; set; }
         public int DisplayOrder { get; set; }
 
@@ -145,6 +162,7 @@ namespace CmsWeb.Areas.Dialog.Models
             OrganizationTypeIds = r.ResourceOrganizationTypes.Select(x => x.OrganizationTypeId);
             CampusId = r.CampusId;
             MemberTypeIds = string.IsNullOrWhiteSpace(r.MemberTypeIds) ? new List<int>() : r.MemberTypeIds.Split(',').Select(int.Parse).ToList();
+            StatusFlagIds = string.IsNullOrWhiteSpace(r.StatusFlagIds) ? new List<int>() : r.StatusFlagIds.Split(',').Select(int.Parse).ToList();
             Description = r.Description;
             DisplayOrder = r.DisplayOrder ?? 0;
         }
@@ -235,6 +253,21 @@ namespace CmsWeb.Areas.Dialog.Models
                     Value = x.Id.ToString()
                 }).ToList();
 
+                return list;
+            }
+        }
+
+        public IEnumerable<SelectListItem> StatusFlags
+        {
+            get
+            {
+                var list = DbUtil.Db.ViewStatusFlagNamesRoles.Select(x => new SelectListItem
+                {
+                    Text = x.Name,
+                    Value = x.Id.ToString()
+                }).ToList();
+
+                list.Insert(0, new SelectListItem { Value = "0", Text = "(none)", Selected = true });
                 return list;
             }
         }

--- a/CmsWeb/Areas/Dialog/Models/ResourceModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/ResourceModel.cs
@@ -21,7 +21,7 @@ namespace CmsWeb.Areas.Dialog.Models
         public IEnumerable<int> OrganizationTypeIds { get; set; } = new List<int>();
         public int? CampusId { get; set; }
         public IEnumerable<int> MemberTypeIds { get; set; }
-        public IEnumerable<int> StatusFlagIds { get; set; }
+        public IEnumerable<string> StatusFlagIds { get; set; }
         public string Description { get; set; }
         public int DisplayOrder { get; set; }
         public IEnumerable<FileUpload> Files { get; set; }
@@ -120,10 +120,10 @@ namespace CmsWeb.Areas.Dialog.Models
         {
             get
             {
-                var list = DbUtil.Db.ViewStatusFlagNamesRoles.Select(x => new SelectListItem
+                var list = DbUtil.Db.ViewStatusFlagLists.Select(x => new SelectListItem
                 {
                     Text = x.Name,
-                    Value = x.Id.ToString()
+                    Value = x.Flag
                 }).ToList();
 
                 list.Insert(0, new SelectListItem { Value = "0", Text = "(none)", Selected = true });
@@ -143,7 +143,7 @@ namespace CmsWeb.Areas.Dialog.Models
         public IEnumerable<int> OrganizationTypeIds { get; set; } = new List<int>();
         public int? CampusId { get; set; }
         public IEnumerable<int> MemberTypeIds { get; set; }
-        public IEnumerable<int> StatusFlagIds { get; set; }
+        public IEnumerable<string> StatusFlagIds { get; set; }
         public string Description { get; set; }
         public int DisplayOrder { get; set; }
 
@@ -162,7 +162,7 @@ namespace CmsWeb.Areas.Dialog.Models
             OrganizationTypeIds = r.ResourceOrganizationTypes.Select(x => x.OrganizationTypeId);
             CampusId = r.CampusId;
             MemberTypeIds = string.IsNullOrWhiteSpace(r.MemberTypeIds) ? new List<int>() : r.MemberTypeIds.Split(',').Select(int.Parse).ToList();
-            StatusFlagIds = string.IsNullOrWhiteSpace(r.StatusFlagIds) ? new List<int>() : r.StatusFlagIds.Split(',').Select(int.Parse).ToList();
+            StatusFlagIds = string.IsNullOrWhiteSpace(r.StatusFlagIds) ? new List<string>() : r.StatusFlagIds.Split(',').ToList();
             Description = r.Description;
             DisplayOrder = r.DisplayOrder ?? 0;
         }
@@ -261,10 +261,10 @@ namespace CmsWeb.Areas.Dialog.Models
         {
             get
             {
-                var list = DbUtil.Db.ViewStatusFlagNamesRoles.Select(x => new SelectListItem
+                var list = DbUtil.Db.ViewStatusFlagLists.Select(x => new SelectListItem
                 {
                     Text = x.Name,
-                    Value = x.Id.ToString()
+                    Value = x.Flag
                 }).ToList();
 
                 list.Insert(0, new SelectListItem { Value = "0", Text = "(none)", Selected = true });

--- a/CmsWeb/Areas/Dialog/Views/AddResource/Index.cshtml
+++ b/CmsWeb/Areas/Dialog/Views/AddResource/Index.cshtml
@@ -67,6 +67,15 @@
                 <div class="row">
                     <div class="col-sm-6">
                         <div class="form-group">
+                            <label for="resource_StatusFlags" class="control-label">Limit to Status Flags</label>
+                            @Html.ListBoxFor(x => x.StatusFlagIds, Model.StatusFlags, new { @class = "form-control select2" })
+                        </div>
+                    </div>
+                    <div class="col-sm-6"></div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="form-group">
                             <label for="resource_File" class="control-label">Files</label>
                             <div id="upload-fields">
                                 @Html.TextBoxFor(m => m.Files, new { type = "file" })

--- a/CmsWeb/Areas/Manage/Controllers/AccountController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/AccountController.cs
@@ -468,7 +468,13 @@ namespace CmsWeb.Areas.Manage.Controllers
         protected void TryLoadAlternateShell()
         {
             var shell = string.Empty;
-            var alternateShellSetting = DbUtil.DbReadOnly.Settings.SingleOrDefault(x => x.Id == LogonPageShellSettingKey);
+            var logonPageShellSettingKey = LogonPageShellSettingKey;
+            var queryString = Request.QueryString["campus"];
+            if (!string.IsNullOrWhiteSpace(queryString))
+            {
+                logonPageShellSettingKey += "-" + queryString.ToUpper();
+            }
+            var alternateShellSetting = DbUtil.DbReadOnly.Settings.SingleOrDefault(x => x.Id == logonPageShellSettingKey);
             if (alternateShellSetting != null)
             {
                 var alternateShell = DbUtil.DbReadOnly.Contents.SingleOrDefault(x => x.Name == alternateShellSetting.SettingX);

--- a/CmsWeb/Areas/Manage/Controllers/ResourceController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/ResourceController.cs
@@ -61,6 +61,7 @@ namespace CmsWeb.Areas.Manage.Controllers
             resource.DivisionId = model.DivisionId;
             resource.CampusId = model.CampusId;
             resource.MemberTypeIds = model.MemberTypeIds != null ? string.Join(",", model.MemberTypeIds) : string.Empty;
+            resource.StatusFlagIds = model.StatusFlagIds != null ? string.Join(",", model.StatusFlagIds) : string.Empty;
             resource.Description = model.Description;
             resource.ResourceTypeId = model.ResourceTypeId;
             resource.ResourceCategoryId = model.ResourceCategoryId;

--- a/CmsWeb/Areas/Manage/Models/ResourceModel.cs
+++ b/CmsWeb/Areas/Manage/Models/ResourceModel.cs
@@ -56,8 +56,8 @@ namespace CmsWeb.Areas.Manage.Models
                 if (string.IsNullOrWhiteSpace(Resource.StatusFlagIds))
                     return string.Empty;
 
-                var statusFlagIds = Resource.StatusFlagIds.Split(',').Select(int.Parse);
-                return string.Join(", ", DbUtil.Db.ViewStatusFlagNamesRoles.Where(x => statusFlagIds.Contains(x.Id.Value)).Select(x => x.Name));
+                var statusFlagIds = Resource.StatusFlagIds.Split(',');
+                return string.Join(", ", DbUtil.Db.ViewStatusFlagLists.Where(x => statusFlagIds.Contains(x.Flag)).Select(x => x.Name));
             }
         }
 

--- a/CmsWeb/Areas/Manage/Models/ResourceModel.cs
+++ b/CmsWeb/Areas/Manage/Models/ResourceModel.cs
@@ -30,7 +30,7 @@ namespace CmsWeb.Areas.Manage.Models
             => string.Join(", ", Resource.ResourceOrganizations.Select(ro => ro.Organization.OrganizationName));
 
         [DisplayName("Organization Types")]
-        public string OrganizationTypeNames 
+        public string OrganizationTypeNames
             => string.Join(", ", Resource.ResourceOrganizationTypes.Select(rot => rot.OrganizationType.Description));
 
         [DisplayName("Congregation")]
@@ -45,6 +45,19 @@ namespace CmsWeb.Areas.Manage.Models
 
                 var memberTypeIds = Resource.MemberTypeIds.Split(',').Select(int.Parse) ;
                 return string.Join(", ", DbUtil.Db.MemberTypes.Where(x => memberTypeIds.Contains(x.Id)).Select(x => x.Description));
+            }
+        }
+
+        [DisplayName("Status Flags")]
+        public string StatusFlags
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(Resource.StatusFlagIds))
+                    return string.Empty;
+
+                var statusFlagIds = Resource.StatusFlagIds.Split(',').Select(int.Parse);
+                return string.Join(", ", DbUtil.Db.ViewStatusFlagNamesRoles.Where(x => statusFlagIds.Contains(x.Id.Value)).Select(x => x.Name));
             }
         }
 

--- a/CmsWeb/Areas/Manage/Views/Resource/Display.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Resource/Display.cshtml
@@ -105,6 +105,12 @@
             </div>
         </div>
         <div class="row">
+            <div class="col-md-12 col-lg-6">
+                @Html.DisplayFor(m => m.StatusFlags)
+            </div>
+            <div class="col-md-12 col-lg-6"></div>
+        </div>
+        <div class="row">
             <div class="col-md-24 col-lg-12">
                 <dl>
                     <dt>@Html.LabelFor(m => m.Resource.Description)</dt>

--- a/CmsWeb/Areas/Manage/Views/Resource/Edit.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Resource/Edit.cshtml
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </div>
-            <div class="row">                
+            <div class="row">
                 <div class="col-sm-6">
                     <div class="form-group">
                         <label for="resource_CampusId" class="control-label">Congregation</label>
@@ -60,9 +60,18 @@
                 <div class="col-sm-6">
                     <div class="form-group">
                         <label for="resource_Roles" class="control-label">Limit to Member Types</label>
-                        @Html.ListBoxFor(x => x.MemberTypeIds, Model.MemberTypes, new { @class = "form-control select2" })                        
+                        @Html.ListBoxFor(x => x.MemberTypeIds, Model.MemberTypes, new { @class = "form-control select2" })
                     </div>
-                </div>                
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-6">
+                    <div class="form-group">
+                        <label for="resource_StatusFlagIds" class="control-label">Limit to Status Flags</label>
+                        @Html.ListBoxFor(x => x.StatusFlagIds, Model.StatusFlags, new { @class = "form-control select2" })
+                    </div>
+                </div>
+                <div class="col-sm-6"></div>
             </div>
             <div class="row">
                 <div class="col-sm-12">

--- a/CmsWeb/Areas/Org/Models/OrgSearchModel.cs
+++ b/CmsWeb/Areas/Org/Models/OrgSearchModel.cs
@@ -291,8 +291,8 @@ namespace CmsWeb.Areas.Search.Models
                     orgIds = DbUtil.Db.OrganizationExtras
                         .Where(x => orgIds.Contains(x.OrganizationId) && x.Field == ev.Key &&
                             (
-                             x.StrValue.ToLower().Contains(ev.Value) ||
-                             x.Data.ToLower().Contains(ev.Value)) ||
+                             x.Type.Equals("Code") ? x.StrValue.ToLower().Equals(ev.Value) : x.StrValue.ToLower().Contains(ev.Value) ||
+                             x.Type.Equals("Code") ? x.Data.ToLower().Equals(ev.Value) : x.Data.ToLower().Contains(ev.Value)) ||
                              x.DateValue != null && x.DateValue.ToString().Contains(ev.Value) ||
                              x.IntValue != null && x.IntValue.ToString().Contains(ev.Value) ||
                              x.BitValue != null && x.BitValue.ToString().Contains(ev.Value)

--- a/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Index.cshtml
@@ -29,10 +29,7 @@
     <div class="col-md-9">
         <div class="box box-responsive">
             <div class="box-content">
-                @if (Model.ShowBlueToolbar)
-                {
-                    @Html.Partial("Toolbar/Toolbar")
-                }
+                @Html.Partial("Toolbar/Toolbar")
                 @Html.Hidden("meetingid", Model.meeting.MeetingId)
                 @Html.Hidden("sort", "false")
                 @Html.Hidden("RegularMeetingHeadCount", RegularMeetingHeadCount)
@@ -132,12 +129,12 @@
                                 </div>
                                 <div class="pull-right">
                                     <a href="/SearchAdd2/Dialog/registered/@Model.meeting.MeetingId" class="btn btn-success hidden searchadd"><i class="fa fa-plus-circle"></i> Add Registered</a>
-                                    @if (Model.ShowAddGuest)
-                                    {
-                                        <a href="/SearchAdd2/Dialog/visitor/@Model.meeting.MeetingId" class="btn btn-success searchadd" title="Click to Add Guests to Meeting"><i class="fa fa-plus-circle"></i> Add Guests</a>
-                                    }
                                 </div>
                             </div>
+                        }
+                        @if (User.IsInRole("Attendance") && Model.ShowAddGuest)
+                        {
+                            <a href="/SearchAdd2/Dialog/visitor/@Model.meeting.MeetingId" class="btn btn-success searchadd pull-right" title="Click to Add Guests to Meeting"><i class="fa fa-plus-circle"></i> Add Guests</a>
                         }
                     </div>
                 </div>

--- a/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Reports.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Reports.cshtml
@@ -1,44 +1,55 @@
-﻿<ul class="dropdown-menu dropdown-menu-large dropdown-menu-right container bluebar-menu-col-1">
+﻿@using CmsData.Classes.RoleChecker
+@{
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
+    var showRollsheet = Model.meeting.MeetingDate >= DateTime.Today && Model.ShowBlueToolbarRollsheet;
+}
+<ul class="dropdown-menu dropdown-menu-large dropdown-menu-right container bluebar-menu-col-1">
     <li class="col-sm-12">
         <ul>
-            <li class="dropdown-header">Reports</li>
-            @if (Model.meeting.MeetingDate >= DateTime.Today && Model.ShowBlueToolbarRollsheet)
+            @if (showRollsheet)
             {
+                <li class="dropdown-header">Reports</li>
                 <li>
                     <a href="/Reports/RollsheetForMeeting/@Model.meeting.MeetingId" target="_blank">
                         <span class="org-context">Rollsheet Report</span>
                     </a>
                 </li>
             }
-            <li>
-                <a href="/Reports/PastAttendee/@Model.meeting.OrganizationId" target="_blank">
-                    <span class="org-context">Recent Attendance Report</span>
-                </a>
-            </li>
-            <li>
-                <a href="/Reports/Attendee/@Model.meeting.MeetingId" target="_blank">
-                    <span class="org-context">Attendee Report</span>
-                </a>
-            </li>
-            <li>
-                <a href="/Reports/VisitsAbsents/@Model.meeting.MeetingId" target="_blank">
-                    <span class="org-context">Guests/Absentees Report</span>
-                </a>
-            </li>
-            <li>
-                <a href="/Reports/VisitsAbsents2/@Model.meeting.MeetingId" id="contactreport" target="_blank">
-                    <span class="org-context">Guests/Absentees Contact Report</span>
-                </a>
-            </li>
-            <li>
-                <a href="/Meeting/AttendanceByGroups/@Model.meeting.MeetingId" target="_blank">
-                    <span class="org-context">Attendance By Groups</span>
-                </a>
-            </li>
-
-            <li class="dropdown-header">Special Pages</li>
+            @if (showAdvanced)
+            {
+                if (!showRollsheet)
+                {
+                    <li class="dropdown-header">Reports</li>
+                }
+                <li>
+                    <a href="/Reports/PastAttendee/@Model.meeting.OrganizationId" target="_blank">
+                        <span class="org-context">Recent Attendance Report</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/Reports/Attendee/@Model.meeting.MeetingId" target="_blank">
+                        <span class="org-context">Attendee Report</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/Reports/VisitsAbsents/@Model.meeting.MeetingId" target="_blank">
+                        <span class="org-context">Guests/Absentees Report</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/Reports/VisitsAbsents2/@Model.meeting.MeetingId" id="contactreport" target="_blank">
+                        <span class="org-context">Guests/Absentees Contact Report</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/Meeting/AttendanceByGroups/@Model.meeting.MeetingId" target="_blank">
+                        <span class="org-context">Attendance By Groups</span>
+                    </a>
+                </li>
+            }
             @if (Model.ShowBlueToolbarIpadAttendance)
             {
+                <li class="dropdown-header">Special Pages</li>
                 <li>
                     <a href="/Meeting/iPad/@Model.meeting.MeetingId">
                         <span class="org-context">iPad Attendance</span>
@@ -50,11 +61,18 @@
                     </a>
                 </li>
             }
-            <li>
-                <a href="/Meeting/tickets/@Model.meeting.MeetingId">
-                    <span class="org-context">Ticketing Attendance</span>
-                </a>
-            </li>
+            @if (showAdvanced)
+            {
+                if (!Model.ShowBlueToolbarIpadAttendance)
+                {
+                    <li class="dropdown-header">Special Pages</li>
+                }
+                <li>
+                    <a href="/Meeting/tickets/@Model.meeting.MeetingId">
+                        <span class="org-context">Ticketing Attendance</span>
+                    </a>
+                </li>
+            }
         </ul>
     </li>
 </ul>

--- a/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Toolbar.cshtml
+++ b/CmsWeb/Areas/Org/Views/Meeting/Toolbar/Toolbar.cshtml
@@ -1,22 +1,39 @@
-﻿<div id="bluetoolbarstop">
+﻿@using CmsData.Classes.RoleChecker
+@{
+    var showAdvanced = !RoleChecker.HasSetting(SettingName.LimitToolbar, false);
+    var showRollsheet = Model.meeting.MeetingDate >= DateTime.Today && Model.ShowBlueToolbarRollsheet;
+}
+<div id="bluetoolbarstop">
     <div id="bluebar-menu" class="btn-group pull-right">
-        <div class="btn-group btn-group-lg dropdown-large">
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                <span class="fa fa-envelope-o"></span>
-            </button>
-            @Html.Partial("Toolbar/Email")
-        </div>
-        <div class="btn-group btn-group-lg dropdown-large">
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                <span class="fa fa-cloud-download"></span>
-            </button>
-            @Html.Partial("Toolbar/Reports")
-        </div>
-        <div class="btn-group btn-group-lg dropdown-large">
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                <span class="fa fa-cog"></span>
-            </button>
-            @Html.Partial("Toolbar/Gear")
-        </div>
+        @if (Model.ShowBlueToolbar)
+        {
+            if (showAdvanced)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-envelope-o"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Email")
+                </div>
+            }
+            if (showAdvanced || showRollsheet || Model.ShowBlueToolbarIpadAttendance)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-cloud-download"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Reports")
+                </div>
+            }
+            if (showAdvanced)
+            {
+                <div class="btn-group btn-group-lg dropdown-large">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                        <span class="fa fa-cog"></span>
+                    </button>
+                    @Html.Partial("Toolbar/Gear")
+                </div>
+            }
+        }
     </div>
 </div>

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
@@ -1,16 +1,15 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Web.WebPages;
 using CmsData;
+using CmsData.View;
 using CmsWeb.Models;
-using MoreLinq;
 using UtilityExtensions;
 
 namespace CmsWeb.Areas.People.Models
 {
-    public class CurrentEnrollments : PagedTableModel<OrganizationMember, OrgMemberInfo>
+    public class CurrentEnrollments : PagedTableModel<InvolvementCurrent, OrgMemberInfo>
     {
         public int? PeopleId { get; set; }
         public Person Person
@@ -23,7 +22,7 @@ namespace CmsWeb.Areas.People.Models
             }
         }
         private Person _person;
-        
+
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;
 
@@ -34,8 +33,8 @@ namespace CmsWeb.Areas.People.Models
                 if (_orgTypesFilter == null)
                 {
                     string defaultFilter;
-                    if(IsInAccess && !IsInOrgLeadersOnly)
-                        defaultFilter = DbUtil.Db.Setting("UX-DefaultAcccessInvolvementOrgTypeFilter", "");
+                    if (IsInAccess && !IsInOrgLeadersOnly)
+                        defaultFilter = DbUtil.Db.Setting("UX-DefaultAccessInvolvementOrgTypeFilter", "");
                     else
                         defaultFilter = DbUtil.Db.Setting("UX-DefaultInvolvementOrgTypeFilter", "");
 
@@ -52,7 +51,7 @@ namespace CmsWeb.Areas.People.Models
                     _orgTypesFilter = new List<string>();
             }
         }
-        private List<string> _orgTypesFilter; 
+        private List<string> _orgTypesFilter;
 
         public IEnumerable<string> OrgTypes
         {
@@ -60,15 +59,15 @@ namespace CmsWeb.Areas.People.Models
             {
                 var excludedTypes =
                     DbUtil.Db.Setting("UX-ExcludeFromInvolvementOrgTypeFilter", "").Split(',').Select(x => x.Trim());
-                return DefineModelList(false).Select(x => x.Organization.OrganizationType.Description).Distinct().Where(x => !excludedTypes.Contains(x));
+                return DefineModelList(false).Select(x => x.OrgType).Distinct().Where(x => !excludedTypes.Contains(x));
             }
-        } 
+        }
 
         public CurrentEnrollments()
             : base("default", "asc", true)
         {}
 
-        public IQueryable<OrganizationMember> DefineModelList(bool useOrgFilter)
+        public IQueryable<InvolvementCurrent> DefineModelList(bool useOrgFilter)
         {
             var limitvisibility = Util2.OrgLeadersOnly || !HttpContext.Current.User.IsInRole("Access");
             var oids = new int[0];
@@ -76,82 +75,75 @@ namespace CmsWeb.Areas.People.Models
                 oids = DbUtil.Db.GetLeaderOrgIds(Util.UserPeopleId);
             var roles = DbUtil.Db.CurrentRoles();
 
-            var modelList = from om in DbUtil.Db.OrganizationMembers
-                            let org = om.Organization
-                            where om.PeopleId == PeopleId
+            return from om in DbUtil.Db.InvolvementCurrent(PeopleId, Util.UserId)
                             where (om.Pending ?? false) == false
-                            where oids.Contains(om.OrganizationId) || !(limitvisibility && om.Organization.SecurityTypeId == 3)
-                            where org.LimitToRole == null || roles.Contains(org.LimitToRole)
-                            where (!useOrgFilter || !OrgTypesFilter.Any() || OrgTypesFilter.Contains(om.Organization.OrganizationType.Description))
+                            where oids.Contains(om.OrganizationId) || !(limitvisibility && om.SecurityTypeId == 3)
+                            where om.LimitToRole == null || roles.Contains(om.LimitToRole)
+                            where (!useOrgFilter || !OrgTypesFilter.Any() || OrgTypesFilter.Contains(om.OrgType))
                             select om;
+        }
 
-            return modelList;
-        } 
-
-        override public IQueryable<OrganizationMember> DefineModelList()
+        override public IQueryable<InvolvementCurrent> DefineModelList()
         {
             return DefineModelList(true);
         }
-        override public IQueryable<OrganizationMember> DefineModelSort(IQueryable<OrganizationMember> q)
+
+        override public IQueryable<InvolvementCurrent> DefineModelSort(IQueryable<InvolvementCurrent> q)
         {
             switch (SortExpression)
             {
                 case "Enroll Date":
                     return from om in q
-                        orderby om.EnrollmentDate descending // this is the natural order for date
+                        orderby om.EnrollDate descending // this is the natural order for date
                         select om;
                 case "Enroll Date desc":
                     return from om in q
-                        orderby om.EnrollmentDate
+                        orderby om.EnrollDate
                         select om;
                 case "Organization":
                     return from om in q
-                        orderby om.Organization.OrganizationName
+                        orderby om.Name
                         select om;
                 case "Organization desc":
                     return from om in q
-                        orderby om.Organization.OrganizationName descending
+                        orderby om.Name descending
                         select om;
                 case "default desc":
                     return from om in q
-                        orderby om.Organization.OrganizationType.Code ?? "z" descending, om.Organization.OrganizationName descending 
+                        orderby om.OrgCode ?? "z" descending, om.Name descending
                         select om;
                 default:
                     return from om in q
-                        orderby om.Organization.OrganizationType.Code ?? "z", om.Organization.OrganizationName
+                        orderby om.OrgTypeSort, om.OrgCode ?? "z", om.Name
                         select om;
             }
         }
 
-        public override IEnumerable<OrgMemberInfo> DefineViewList(IQueryable<OrganizationMember> q)
+        public override IEnumerable<OrgMemberInfo> DefineViewList(IQueryable<InvolvementCurrent> q)
         {
             var viewList = from om in q
-                   let sc = om.Organization.OrgSchedules.FirstOrDefault() // SCHED
                    select new OrgMemberInfo
                    {
                        OrgId = om.OrganizationId,
                        PeopleId = om.PeopleId,
-                       Name = om.Organization.OrganizationName,
-                       Location = om.Organization.Location,
-                       LeaderName = om.Organization.LeaderName,
-                       MeetingTime = sc.MeetingTime,
-                       MemberType = om.MemberType.Description,
-                       LeaderId = om.Organization.LeaderId,
-                       EnrollDate = om.EnrollmentDate,
+                       Name = om.Name,
+                       Location = om.Location,
+                       LeaderName = om.LeaderName,
+                       MeetingTime = om.MeetingTime,
+                       MemberType = om.MemberType,
+                       LeaderId = om.LeaderId,
+                       EnrollDate = om.EnrollDate,
                        AttendPct = om.AttendPct,
-                       DivisionName = om.Organization.Division.Name,
-                       ProgramName = om.Organization.Division.Program.Name,
-                       OrgType = om.Organization.OrganizationType.Description ?? "Other",
-                       HasDirectory = (om.Organization.PublishDirectory ?? 0) > 0,
-                       IsLeaderAttendanceType = (om.MemberType.AttendanceTypeId ?? 0) == 10
+                       DivisionName = om.DivisionName,
+                       ProgramName = om.ProgramName,
+                       OrgType = om.OrgType,
+                       HasDirectory = om.HasDirectory.GetValueOrDefault(),
+                       IsLeaderAttendanceType = om.IsLeaderAttendanceType.GetValueOrDefault()
                    };
 
             if (DbUtil.Db.Setting("UX-ShowChildOrgsOnInvolvementTabs"))
             {
                 var viewListAsList = viewList.ToList();
-                if (OrgTypesFilter.Count > 0)
-                    viewListAsList = viewListAsList.OrderBy(om => OrgTypesFilter.IndexOf(om.OrgType)).ToList();
-
                 var parentIds = viewListAsList.Select(x => x.OrgId).ToList();
 
                 var childGroups = from org in DbUtil.Db.Organizations

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
@@ -23,9 +23,7 @@ namespace CmsWeb.Areas.People.Models
             }
         }
         private Person _person;
-
-        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
-
+        
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;
 

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/CurrentEnrollments.cs
@@ -24,17 +24,7 @@ namespace CmsWeb.Areas.People.Models
         }
         private Person _person;
 
-        public bool HasDefaultFilterSetting
-        {
-            get
-            {
-                if (IsInAccess && !IsInOrgLeadersOnly)
-                    return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultAcccessInvolvementOrgTypeFilter", string.Empty));
-
-                return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultInvolvementOrgTypeFilter", string.Empty));
-            }
-            
-        }
+        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
 
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/PendingEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/PendingEnrollments.cs
@@ -23,17 +23,7 @@ namespace CmsWeb.Areas.People.Models
         }
         private Person _person;
 
-        public bool HasDefaultFilterSetting
-        {
-            get
-            {
-                if (IsInAccess && !IsInOrgLeadersOnly)
-                    return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultAcccessInvolvementOrgTypeFilter", string.Empty));
-
-                return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultInvolvementOrgTypeFilter", string.Empty));
-            }
-
-        }
+        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
 
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/PendingEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/PendingEnrollments.cs
@@ -22,9 +22,7 @@ namespace CmsWeb.Areas.People.Models
             }
         }
         private Person _person;
-
-        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
-
+        
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;
 

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/PreviousEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/PreviousEnrollments.cs
@@ -23,17 +23,7 @@ namespace CmsWeb.Areas.People.Models
         }
         private Person _person;
 
-        public bool HasDefaultFilterSetting
-        {
-            get
-            {
-                if (IsInAccess && !IsInOrgLeadersOnly)
-                    return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultAcccessInvolvementOrgTypeFilter", string.Empty));
-
-                return !string.IsNullOrWhiteSpace(DbUtil.Db.Setting("UX-DefaultInvolvementOrgTypeFilter", string.Empty));
-            }
-
-        }
+        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
 
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/PreviousEnrollments.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/PreviousEnrollments.cs
@@ -22,9 +22,7 @@ namespace CmsWeb.Areas.People.Models
             }
         }
         private Person _person;
-
-        public bool HasDefaultFilterSetting => DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true);
-
+        
         private bool IsInAccess => WebPageContext.Current?.Page?.User?.IsInRole("Access") ?? false;
         private bool IsInOrgLeadersOnly => WebPageContext.Current?.Page?.User?.IsInRole("OrgLeadersOnly") ?? false;
 

--- a/CmsWeb/Areas/People/Models/Person/PersonModel.cs
+++ b/CmsWeb/Areas/People/Models/Person/PersonModel.cs
@@ -347,14 +347,14 @@ namespace CmsWeb.Areas.People.Models
 
         private bool ShouldShowResource(Resource resource)
         {
-            var shouldShow = true;
-            var statusFlagIds = resource.StatusFlagIds?.Split(',') ?? new string[] { };
-            foreach (var flagId in statusFlagIds.Where(x => !string.IsNullOrWhiteSpace(x)))
-            {
-                var statusFlag = DbUtil.Db.ViewStatusFlagNamesRoles.SingleOrDefault(x => x.Id.ToString().Equals(flagId));
-                if (statusFlag == null) continue;
+            var resourceStatusFlags = resource.StatusFlagIds?.Split(',') ?? new string[] { };
+            var personStatusFlags = DbUtil.Db.ViewAllStatusFlags.Where(sf => sf.PeopleId == PeopleId).Select(x => x.Flag).ToList();
 
-                shouldShow = StatusFlags.Contains(statusFlag.Name);
+            var shouldShow = true;
+            foreach (var flag in resourceStatusFlags.Where(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                if (!personStatusFlags.Contains(flag))
+                    shouldShow = false;
             }
 
             return shouldShow;

--- a/CmsWeb/Areas/People/Models/Person/PersonModel.cs
+++ b/CmsWeb/Areas/People/Models/Person/PersonModel.cs
@@ -349,9 +349,11 @@ namespace CmsWeb.Areas.People.Models
         {
             var shouldShow = true;
             var statusFlagIds = resource.StatusFlagIds?.Split(',') ?? new string[] { };
-            foreach (var flagId in statusFlagIds)
+            foreach (var flagId in statusFlagIds.Where(x => !string.IsNullOrWhiteSpace(x)))
             {
-                var statusFlag = DbUtil.Db.ViewStatusFlagNamesRoles.Single(x => x.Id.ToString().Equals(flagId));
+                var statusFlag = DbUtil.Db.ViewStatusFlagNamesRoles.SingleOrDefault(x => x.Id.ToString().Equals(flagId));
+                if (statusFlag == null) continue;
+
                 shouldShow = StatusFlags.Contains(statusFlag.Name);
             }
 

--- a/CmsWeb/Areas/People/Models/Person/PersonModel.cs
+++ b/CmsWeb/Areas/People/Models/Person/PersonModel.cs
@@ -258,16 +258,7 @@ namespace CmsWeb.Areas.People.Models
 
                 foreach (var resource in resources)
                 {
-                    var hasStatusFlagAccess = false;
-                    var statusFlags = resource.StatusFlagIds?.Split(',') ?? new string[] {};
-                    foreach (var flag in statusFlags)
-                    {
-                        if (StatusFlags.Contains(flag))
-                            hasStatusFlagAccess = true;
-                    }
-
-                    if(hasStatusFlagAccess)
-                        continue;
+                    if (!ShouldShowResource(resource)) continue;
 
                     var noMemberTypesSet = string.IsNullOrEmpty(resource.MemberTypeIds);
 
@@ -352,6 +343,19 @@ namespace CmsWeb.Areas.People.Models
 
                 return _resourceTypes;
             }
+        }
+
+        private bool ShouldShowResource(Resource resource)
+        {
+            var shouldShow = true;
+            var statusFlagIds = resource.StatusFlagIds?.Split(',') ?? new string[] { };
+            foreach (var flagId in statusFlagIds)
+            {
+                var statusFlag = DbUtil.Db.ViewStatusFlagNamesRoles.Single(x => x.Id.ToString().Equals(flagId));
+                shouldShow = StatusFlags.Contains(statusFlag.Name);
+            }
+
+            return shouldShow;
         }
     }
 }

--- a/CmsWeb/Areas/People/Models/Person/PersonModel.cs
+++ b/CmsWeb/Areas/People/Models/Person/PersonModel.cs
@@ -258,6 +258,17 @@ namespace CmsWeb.Areas.People.Models
 
                 foreach (var resource in resources)
                 {
+                    var hasStatusFlagAccess = false;
+                    var statusFlags = resource.StatusFlagIds?.Split(',') ?? new string[] {};
+                    foreach (var flag in statusFlags)
+                    {
+                        if (StatusFlags.Contains(flag))
+                            hasStatusFlagAccess = true;
+                    }
+
+                    if(hasStatusFlagAccess)
+                        continue;
+
                     var noMemberTypesSet = string.IsNullOrEmpty(resource.MemberTypeIds);
 
                     var noOrgRestrictionsSet = !resource.ResourceOrganizations.Any();

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
@@ -1,5 +1,6 @@
 ﻿@using CmsData
 @using CmsWeb.Areas.People.Models
+@using CsQuery.ExtensionMethods.Internal
 @using UtilityExtensions
 @model CurrentEnrollments
 @{
@@ -12,7 +13,10 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @Html.Partial("PagerTop", Model)
+            @if (Model.HasDefaultFilterSetting)
+            {
+                @Html.Partial("PagerTop", Model)
+            }
             <div class="table-responsive">
                 <table class="expanding table table-hover">
                     @if(!columnset.HasOrgTypeColumns || Model.Sort != "default")

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
@@ -13,10 +13,7 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @if (Model.HasDefaultFilterSetting)
-            {
-                @Html.Partial("PagerTop", Model)
-            }
+            @Html.Partial("PagerTop", Model)
             <div class="table-responsive">
                 <table class="expanding table table-hover">
                     @if(!columnset.HasOrgTypeColumns || Model.Sort != "default")

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Current.cshtml
@@ -10,7 +10,6 @@
 }
 <form class="non-modal ajax">
     @FormAction()
-    <br/>
     <div class="row">
         <div class="col-sm-12">
             @Html.Partial("PagerTop", Model)

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
@@ -9,7 +9,6 @@
 }
 <form class="non-modal ajax">
     @FormAction()
-    <br/>
     <div class="row">
         <div class="col-sm-12">
             @Html.Partial("PagerTop", Model)

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
@@ -12,7 +12,10 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @Html.Partial("PagerTop", Model)
+            @if (Model.HasDefaultFilterSetting)
+            {
+                @Html.Partial("PagerTop", Model)
+            }
             <div class="table-responsive">
                 <table class="expanding table table-hover">
                     <thead>

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Pending.cshtml
@@ -12,10 +12,7 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @if (Model.HasDefaultFilterSetting)
-            {
-                @Html.Partial("PagerTop", Model)
-            }
+            @Html.Partial("PagerTop", Model)
             <div class="table-responsive">
                 <table class="expanding table table-hover">
                     <thead>

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
@@ -13,10 +13,7 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @if (Model.HasDefaultFilterSetting)
-            {
-                @Html.Partial("PagerTop", Model)
-            }
+            @Html.Partial("PagerTop", Model)
             <div class="table-responsive">
                 <table class="enrollments expanding table table-hover">
                     <thead>

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
@@ -13,7 +13,10 @@
     <br/>
     <div class="row">
         <div class="col-sm-12">
-            @Html.Partial("PagerTop", Model)
+            @if (Model.HasDefaultFilterSetting)
+            {
+                @Html.Partial("PagerTop", Model)
+            }
             <div class="table-responsive">
                 <table class="enrollments expanding table table-hover">
                     <thead>
@@ -36,7 +39,7 @@
                     @foreach (var om in Model.ViewList())
                     {
                         rownum++;
-                        var oddrow = rownum%2 == 0 ? "oddrow" : "";
+                        var oddrow = rownum % 2 == 0 ? "oddrow" : "";
                         if (om.OrgType != pOrgType && Model.Sort == "default")
                         {
                             pOrgType = om.OrgType;

--- a/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Enrollment/Previous.cshtml
@@ -10,7 +10,6 @@
 }
 <form class="non-modal ajax">
     @FormAction()
-    <br/>
     <div class="row">
         <div class="col-sm-12">
             @Html.Partial("PagerTop", Model)

--- a/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
@@ -1,11 +1,11 @@
-﻿@using CmsData
+﻿@using CmsWeb.Areas.Manage.Models
 @model CmsWeb.Areas.People.Models.PersonModel
 
-<ul class="nav nav-pills subnav hidden-sm hidden-xs" data-tabparent="system">
+<ul class="nav nav-pills subnav hidden-sm hidden-xs" data-tabparent="resources">
     @for (var i = 0; i < Model.ResourceTypes.Count; i++)
        {
         <li class="resource-type-tab @(i == 0 ? "active" : null)" data-id="@Model.ResourceTypes[i].ResourceType.ResourceTypeId">
-            <a href = "#resourcetab@(Model.ResourceTypes[i].ResourceType.ResourceTypeId)" data-toggle="tab">
+            <a href = "#@(Model.ResourceTypes[i].ResourceType.Name.ToLower().Replace(" ", ""))" data-toggle="tab">
                 <span>@Model.ResourceTypes[i].ResourceType.Name</span>
             </a>
         </li>
@@ -57,7 +57,7 @@
 
 
         <div class="tab-pane @(i == 0 ? "active" : null)"
-             id="resourcetab@(resourceTypeGroup.ResourceType.ResourceTypeId)">
+             id="@(resourceTypeGroup.ResourceType.Name.ToLower().Replace(" ", ""))">
             <div class="panel-group" id="accordion@(i)" role="tablist">
                 @foreach (var category in resourceTypeGroup.Resources.GroupBy(x => x.ResourceCategory).OrderBy(x => x.Key.DisplayOrder))
                 {
@@ -118,3 +118,21 @@
     </div>
 
         <br />
+
+<script src='//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js'></script>
+<script type="text/javascript">
+    $(function () {
+        var tab = window.location.hash;
+        $.cookie('lasttab', tab);
+
+        @foreach (ResourceTypeModel resourceModel in Model.ResourceTypes)
+        {
+            <text>
+                if (tab === '#tab-@resourceModel.ResourceType.Name.ToLower().Replace(" ", "")') {
+                    var id = "#@resourceModel.ResourceType.Name.ToLower().Replace(" ", "")";
+                    $("a[href='" + id + "']").click().tab("show");
+                }
+            </text>
+        }
+    });
+</script>

--- a/CmsWeb/Content/touchpoint/js/people/person.js
+++ b/CmsWeb/Content/touchpoint/js/people/person.js
@@ -353,6 +353,7 @@
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         e.preventDefault();
         var tab = $(e.target).attr('href').replace("#", "#tab-");
+        if (tab === "#tab-resources") return false;
         window.location.hash = tab;
         $.cookie('lasttab', tab);
 

--- a/CmsWeb/Views/Shared/PagerTop.cshtml
+++ b/CmsWeb/Views/Shared/PagerTop.cshtml
@@ -2,7 +2,7 @@
 @model CmsWeb.Models.PagerModel2
 @{
     var showOrgTypeFilter = Model.GetType() == typeof (CurrentEnrollments) || Model.GetType() == typeof (PreviousEnrollments) || Model.GetType() == typeof (PendingEnrollments);
-    var colClasses = showOrgTypeFilter ? "col-lg-8 col-md-8 col-sm-8" : "col-lg-4 col-md-4 col-sm-4";
+    var colClasses = showOrgTypeFilter ? "col-lg-12 col-md-12 col-sm-12" : "col-lg-4 col-md-4 col-sm-4";
 }
 <div class="row hidden-print">
     <div class="@colClasses form-inline">
@@ -16,6 +16,7 @@
             {
                 <span>Show </span>@Html.DropDownList("PageSize", Model.PageSizeList(), new {onchange = "$.setPageSize(this)", @class = "form-control"})<span> rows</span>
             }
+            @Html.Partial("Pagination", Model)
         }
         @if (showOrgTypeFilter && DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true))
         {
@@ -34,5 +35,4 @@
             </script>
         }
     </div>
-    @Html.Partial("Pagination", Model)
 </div>

--- a/CmsWeb/Views/Shared/PagerTop.cshtml
+++ b/CmsWeb/Views/Shared/PagerTop.cshtml
@@ -17,7 +17,7 @@
                 <span>Show </span>@Html.DropDownList("PageSize", Model.PageSizeList(), new {onchange = "$.setPageSize(this)", @class = "form-control"})<span> rows</span>
             }
         }
-        @if (showOrgTypeFilter)
+        @if (showOrgTypeFilter && DbUtil.Db.Setting("UX-ShowInvolvementOrgTypeFilter", true))
         {
             <span> of types </span><input name="OrgTypesFilter" value="@(string.Join(" ,", ((dynamic)Model).OrgTypesFilter ?? new List<string>()))" class="form-control org-types-filter" id="org-types-filter-@Model.GetType().Name" style="display: inline-block; min-width:180px" />
             <script>

--- a/CmsWeb/Views/Shared/Pagination.cshtml
+++ b/CmsWeb/Views/Shared/Pagination.cshtml
@@ -4,7 +4,6 @@
 }
 @if (pglist.Count > 1)
 {
-    <div class="col-lg-8 col-md-8 col-sm-8">
         <div class="pull-right">
             <ul class="pagination">
                 @if (Model.Page > 1)
@@ -53,5 +52,4 @@
                 }
             </ul>
         </div>
-    </div>
 }


### PR DESCRIPTION
Hi David - this PR is the follow-up to #171 with the appropriate database changes!

This PR includes the latest requested changes from Redeemer.

Summary of Changes:
* Involvement tab (current, previous and pending)
  * Added a new admin setting to allow for hiding the organization type filters
  * Allow the previous admin setting we added also define the order of organizations displayed (e.g. if Community Group, Mailing List, Other then display in that order versus in alphabetical order)
* Custom skin for congregation login pages (i.e. campus-specific skins for the login page)
* Follow up items from our last PR to allow for further customization of meeting-pages via XML special content (see #163)
* Allow for Resources to be locked down by status flag
* Added a few minor bug fixes
  * the org search page wasn't returning results correctly if someone searched for group type of men (because it was a contains check)
  * supported deep linking of resource sub-tabs (on the profile page)