### PR TITLE
Fix Resource Sub-Tabs on Mobile (#93)

### DIFF
--- a/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
@@ -123,7 +123,6 @@
 <script type="text/javascript">
     $(function () {
         var tab = window.location.hash;
-        $.cookie('lasttab', tab);
 
         @foreach (ResourceTypeModel resourceModel in Model.ResourceTypes)
         {

--- a/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Resources/Tab.cshtml
@@ -15,7 +15,7 @@
     <select class="form-control visible-sm-block visible-xs-block nav-select-pills">
     @for (var i = 0; i<Model.ResourceTypes.Count; i++)
     {
-        <option value = "#resourcetab@(Model.ResourceTypes[i].ResourceType.ResourceTypeId)" > @Model.ResourceTypes[i].ResourceType.Name </option>
+        <option value = "#@(Model.ResourceTypes[i].ResourceType.Name.ToLower().Replace(" ", ""))" > @Model.ResourceTypes[i].ResourceType.Name </option>
     }
 
     </select>
@@ -131,6 +131,7 @@
                 if (tab === '#tab-@resourceModel.ResourceType.Name.ToLower().Replace(" ", "")') {
                     var id = "#@resourceModel.ResourceType.Name.ToLower().Replace(" ", "")";
                     $("a[href='" + id + "']").click().tab("show");
+                    $("option[value='" + id + "']").prop('selected', true);
                 }
             </text>
         }

--- a/CmsWeb/Content/touchpoint/js/people/person.js
+++ b/CmsWeb/Content/touchpoint/js/people/person.js
@@ -353,7 +353,6 @@
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         e.preventDefault();
         var tab = $(e.target).attr('href').replace("#", "#tab-");
-        if (tab === "#tab-resources") return false;
         window.location.hash = tab;
         $.cookie('lasttab', tab);
 


### PR DESCRIPTION
Good afternoon David - we found a minor bug with resource sub-tabs _specifically on mobile views_. This fix adds the deep link change so that mobile resource sub tabs work as well.

For a little bit more clarification, this fix is only related to the Resource tab on the Profile page so it will only affect churches that have the Resources feature enabled and are viewing the tab on mobile.

Thanks!