### PR TITLE
Add extra value support to contacts

### DIFF
--- a/CmsData/Classes/ExtraValues/Code.cs
+++ b/CmsData/Classes/ExtraValues/Code.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Serialization;
+
+namespace CmsData.Classes.ExtraValues
+{
+    public class Code
+    {
+        [XmlAttribute] public string Metadata { get; set; }
+        [XmlText] public string Text { get; set; }
+    }
+}

--- a/CmsData/Classes/ExtraValues/NewStandard.cs
+++ b/CmsData/Classes/ExtraValues/NewStandard.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using CmsData.Classes.ExtraValues;
 using UtilityExtensions;
 
 namespace CmsData.ExtraValue
@@ -26,7 +27,7 @@ Option 2
                 : Type == "Code"
                     ? Codes ?? defaultCodes
                     : null;
-            var a = codes.SplitLines(noblanks: true).Select(ss => BitPrefix + ss).ToList();
+            var a = codes.SplitLines(noblanks: true).Select(ss => new Code { Text = BitPrefix + ss }).ToList();
             var v = new Value
             {
                 Type = Type,

--- a/CmsData/Classes/ExtraValues/Value.cs
+++ b/CmsData/Classes/ExtraValues/Value.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Web;
 using System.Xml.Serialization;
+using CmsData.Classes.ExtraValues;
 using CmsData.Classes.RoleChecker;
 using UtilityExtensions;
 
@@ -17,7 +18,7 @@ namespace CmsData.ExtraValue
         [XmlAttribute] public string Link { get; set; }
 
         [XmlElement("Code")]
-        public List<string> Codes { get; set; }
+        public List<Code> Codes { get; set; }
 
 
         [XmlIgnore] public int Order;

--- a/CmsData/Classes/ExtraValues/Views.cs
+++ b/CmsData/Classes/ExtraValues/Views.cs
@@ -93,11 +93,12 @@ namespace CmsData.ExtraValue
             public View view;
             public Value value;
         }
-        public static ViewValue GetViewsViewValue(CMSDataContext db, string table, string name)
+        public static ViewValue GetViewsViewValue(CMSDataContext db, string table, string name, string location)
         {
             var views = GetViews(db, nocache: true);
             var i = from view in views.List
                     where view.Table == table
+                    where view.Location == location
                     from value in view.Values
                     where value.Name == name
                     select new ViewValue

--- a/CmsData/Classes/ExtraValues/Views.cs
+++ b/CmsData/Classes/ExtraValues/Views.cs
@@ -27,12 +27,21 @@ namespace CmsData.ExtraValue
                 return new Views();
             return f;
         }
-        public static List<Value> GetStandardExtraValues(CMSDataContext db, string table, bool nocache = false)
+        public static List<Value> GetStandardExtraValues(CMSDataContext db, string table, bool nocache = false, string location = null)
         {
+            if (location != null)
+            {
+                return (from vv in GetViews(db, nocache).List
+                        where vv.Table == table
+                        where vv.Location == location
+                        from v in vv.Values
+                        select v).ToList();
+            }
+
             return (from vv in GetViews(db, nocache).List
-                    where vv.Table == table
-                    from v in vv.Values
-                    select v).ToList();
+                where vv.Table == table
+                from v in vv.Values
+                select v).ToList();
         }
 
         public class StandardValueNameType

--- a/CmsData/Classes/ExtraValues/Views.cs
+++ b/CmsData/Classes/ExtraValues/Views.cs
@@ -58,7 +58,7 @@ namespace CmsData.ExtraValue
                          from v in vv.Codes
                          select new StandardValueNameType()
                          { 
-                             Name = v, 
+                             Name = v.Text, 
                              Type = vv.Type,
                              CanView = vv.UserCanView(db)
                          }).ToList();

--- a/CmsData/Classes/HealthChecker/HealthChecker.cs
+++ b/CmsData/Classes/HealthChecker/HealthChecker.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+
+namespace CmsData.Classes.HealthChecker
+{
+    public static class HealthChecker
+    {
+        public static MetricName GetHealthMetric(int orgId)
+        {
+            var organization = DbUtil.Db.Organizations.SingleOrDefault(x => x.OrganizationId == orgId);
+            if (organization?.contactsHad == null) return MetricName.UNKNOWN;
+
+            var groupHealth = MetricName.GREEN;
+            foreach (var contact in organization.contactsHad)
+            {
+                if (contact.ContactExtras == null) return MetricName.UNKNOWN;
+
+                foreach (var contactExtra in contact.ContactExtras)
+                {
+                    if (contactExtra.Metadata == null) continue;
+
+                    Enum.TryParse(contactExtra.Metadata.ToUpper(), out MetricName contactHealth);
+                    if (contactHealth > groupHealth) groupHealth = contactHealth;
+                }
+            }
+
+            return groupHealth;
+        }
+    }
+
+    public enum MetricName
+    {
+        UNKNOWN = 0,
+        RED = 3,
+        YELLOW = 2,
+        GREEN = 1
+    }
+}

--- a/CmsData/Classes/HealthChecker/HealthChecker.cs
+++ b/CmsData/Classes/HealthChecker/HealthChecker.cs
@@ -8,7 +8,7 @@ namespace CmsData.Classes.HealthChecker
         public static MetricName GetHealthMetric(int orgId)
         {
             var organization = DbUtil.Db.Organizations.SingleOrDefault(x => x.OrganizationId == orgId);
-            if (organization?.contactsHad == null) return MetricName.UNKNOWN;
+            if (organization == null || organization.contactsHad.Count == 0) return MetricName.UNKNOWN;
 
             var groupHealth = MetricName.GREEN;
             foreach (var contact in organization.contactsHad)
@@ -30,8 +30,9 @@ namespace CmsData.Classes.HealthChecker
         public static DateTime? GetLastVisit(int orgId)
         {
             var organization = DbUtil.Db.Organizations.SingleOrDefault(x => x.OrganizationId == orgId);
+            if (organization?.contactsHad.Count == 0) return null;
 
-            return organization?.contactsHad?.Max(x => x.ContactDate);
+            return organization?.contactsHad.Max(x => x.ContactDate);
         }
     }
 

--- a/CmsData/Classes/HealthChecker/HealthChecker.cs
+++ b/CmsData/Classes/HealthChecker/HealthChecker.cs
@@ -26,6 +26,13 @@ namespace CmsData.Classes.HealthChecker
 
             return groupHealth;
         }
+
+        public static DateTime? GetLastVisit(int orgId)
+        {
+            var organization = DbUtil.Db.Organizations.SingleOrDefault(x => x.OrganizationId == orgId);
+
+            return organization?.contactsHad?.Max(x => x.ContactDate);
+        }
     }
 
     public enum MetricName

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -128,8 +128,7 @@ namespace CmsData.Classes.RoleChecker
         CanEditCGInfoEVs,
         EditMemberData,
         OrgMembersDropAdd,
-        OtherGroupsContentOnly,
-        Contact_HideDefaultCheckboxes
+        OtherGroupsContentOnly
         // ReSharper restore InconsistentNaming
     }
 }

--- a/CmsData/Classes/RoleChecker/RoleChecker.cs
+++ b/CmsData/Classes/RoleChecker/RoleChecker.cs
@@ -128,7 +128,8 @@ namespace CmsData.Classes.RoleChecker
         CanEditCGInfoEVs,
         EditMemberData,
         OrgMembersDropAdd,
-        OtherGroupsContentOnly
+        OtherGroupsContentOnly,
+        Contact_HideDefaultCheckboxes
         // ReSharper restore InconsistentNaming
     }
 }

--- a/CmsData/CmsData.csproj
+++ b/CmsData/CmsData.csproj
@@ -447,6 +447,7 @@
     <Compile Include="API\QueryFunctions\Attendance.cs" />
     <Compile Include="API\QueryFunctions\Contributions.cs" />
     <Compile Include="API\QueryFunctions\Query.cs" />
+    <Compile Include="Classes\ExtraValues\Code.cs" />
     <Compile Include="Classes\ExtraValues\NewStandard.cs" />
     <Compile Include="Classes\GoogleCloudMessaging\GCMData.cs" />
     <Compile Include="Classes\GoogleCloudMessaging\GCMHelper.cs" />

--- a/CmsData/CmsData.csproj
+++ b/CmsData/CmsData.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Classes\GoogleCloudMessaging\GCMPayload.cs" />
     <Compile Include="Classes\GoogleCloudMessaging\GCMResponse.cs" />
     <Compile Include="Classes\GoogleCloudMessaging\GCMResponseResult.cs" />
+    <Compile Include="Classes\HealthChecker\HealthChecker.cs" />
     <Compile Include="Classes\OnlineRegSummaryText\OnlineRegPersonModel0.cs" />
     <Compile Include="Classes\OnlineRegSummaryText\SummaryInfo.cs" />
     <Compile Include="Classes\RoleChecker\RoleChecker.cs" />

--- a/CmsData/DbUtil/Context.cs
+++ b/CmsData/DbUtil/Context.cs
@@ -167,6 +167,10 @@ namespace CmsData
         {
             return this.Organizations.FirstOrDefault(o => o.OrganizationId == id);
         }
+        public Contact LoadContactById(int? id)
+        {
+            return this.Contacts.FirstOrDefault(o => o.ContactId == id);
+        }
         public OrgFilter OrgFilter(Guid? id)
         {
             var filter = OrgFilters.SingleOrDefault(vv => vv.QueryId == id);

--- a/CmsData/DbUtil/ITableWithExtraValues.cs
+++ b/CmsData/DbUtil/ITableWithExtraValues.cs
@@ -4,7 +4,7 @@ namespace CmsData
 {
     public interface ITableWithExtraValues
     {
-        void AddEditExtraCode(string field, string value);
+        void AddEditExtraCode(string field, string value, string location = null);
         void AddEditExtraText(string field, string value, DateTime? dt = null);
         void AddEditExtraDate(string field, DateTime? value);
         void AddToExtraText(string field, string value);

--- a/CmsData/DbUtil/ITableWithExtraValues.cs
+++ b/CmsData/DbUtil/ITableWithExtraValues.cs
@@ -9,7 +9,7 @@ namespace CmsData
         void AddEditExtraDate(string field, DateTime? value);
         void AddToExtraText(string field, string value);
         void AddEditExtraInt(string field, int value);
-        void AddEditExtraBool(string field, bool tf);
+        void AddEditExtraBool(string field, bool tf, string name = null, string location = null);
         void AddEditExtraValue(string field, string code, DateTime? date, string text, bool? bit, int? intn, DateTime? dt = null);
         void RemoveExtraValue(CMSDataContext db, string field);
         void LogExtraValue(string op, string field);

--- a/CmsData/Extensions/Contact.cs
+++ b/CmsData/Extensions/Contact.cs
@@ -150,13 +150,14 @@ namespace CmsData
             ev.TransactionTime = DateTime.Now;
         }
 
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;
             var ev = GetExtraValue(field);
             ev.BitValue = tf;
             ev.TransactionTime = DateTime.Now;
+            ev.Metadata = RetrieveMetadata(name, field, location);
         }
 
         public void AddEditExtraValue(string field, string code, DateTime? date, string text, bool? bit, int? intn, DateTime? dt = null)

--- a/CmsData/Extensions/Contact.cs
+++ b/CmsData/Extensions/Contact.cs
@@ -7,7 +7,7 @@ using UtilityExtensions;
 
 namespace CmsData
 {
-    public partial class Contact
+    public partial class Contact : ITableWithExtraValues
     {
         public static int AddContact(Guid qid, int? MakerId = null)
         {
@@ -98,6 +98,106 @@ namespace CmsData
                 db.SubmitChanges();
             }
             return r;
+        }
+
+        public void AddEditExtraCode(string field, string value)
+        {
+            if (!field.HasValue())
+                return;
+            if (!value.HasValue())
+                return;
+            var ev = GetExtraValue(field);
+            ev.StrValue = value;
+            ev.TransactionTime = DateTime.Now;
+        }
+
+        public void AddEditExtraText(string field, string value, DateTime? dt = null)
+        {
+            if (!value.HasValue())
+                return;
+            var ev = GetExtraValue(field);
+            ev.Data = value;
+            ev.TransactionTime = dt ?? DateTime.Now;
+        }
+
+        public void AddEditExtraDate(string field, DateTime? value)
+        {
+            if (!value.HasValue)
+                return;
+            var ev = GetExtraValue(field);
+            ev.DateValue = value;
+            ev.TransactionTime = DateTime.Now;
+        }
+
+        public void AddToExtraText(string field, string value)
+        {
+            if (!value.HasValue())
+                return;
+            var ev = GetExtraValue(field);
+            ev.DataType = "text";
+            if (ev.Data.HasValue())
+                ev.Data = value + "\n" + ev.Data;
+            else
+                ev.Data = value;
+        }
+
+        public void AddEditExtraInt(string field, int value)
+        {
+            var ev = GetExtraValue(field);
+            ev.IntValue = value;
+            ev.TransactionTime = DateTime.Now;
+        }
+
+        public void AddEditExtraBool(string field, bool tf)
+        {
+            if (!field.HasValue())
+                return;
+            var ev = GetExtraValue(field);
+            ev.BitValue = tf;
+            ev.TransactionTime = DateTime.Now;
+        }
+
+        public void AddEditExtraValue(string field, string code, DateTime? date, string text, bool? bit, int? intn, DateTime? dt = null)
+        {
+            var ev = GetExtraValue(field);
+            ev.StrValue = code;
+            ev.Data = text;
+            ev.DateValue = date;
+            ev.IntValue = intn;
+            ev.BitValue = bit;
+            ev.UseAllValues = true;
+            ev.TransactionTime = dt ?? DateTime.Now;
+        }
+
+        public void RemoveExtraValue(CMSDataContext db, string field)
+        {
+            var ev = ContactExtras.AsEnumerable().FirstOrDefault(ee => string.Compare(ee.Field, field, ignoreCase: true) == 0);
+            if (ev != null)
+            {
+                db.ContactExtras.DeleteOnSubmit(ev);
+                ev.TransactionTime = DateTime.Now;
+            }
+        }
+
+        public void LogExtraValue(string op, string field)
+        {
+            DbUtil.LogActivity($"EVContact {op}:{field}", ContactId);
+        }
+
+        public ContactExtra GetExtraValue(string field)
+        {
+            var ev = ContactExtras.AsEnumerable().FirstOrDefault(ee => ee.Field.Equal(field));
+            if (ev == null)
+            {
+                ev = new ContactExtra()
+                {
+                    ContactId = ContactId,
+                    Field = field,
+
+                };
+                ContactExtras.Add(ev);
+            }
+            return ev;
         }
     }
 }

--- a/CmsData/Extensions/Contact.cs
+++ b/CmsData/Extensions/Contact.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using CmsData.Codes;
+using CmsData.ExtraValue;
 using UtilityExtensions;
 
 namespace CmsData
@@ -109,6 +110,7 @@ namespace CmsData
             var ev = GetExtraValue(field);
             ev.StrValue = value;
             ev.TransactionTime = DateTime.Now;
+            ev.Metadata = RetrieveMetadata(field, value);
         }
 
         public void AddEditExtraText(string field, string value, DateTime? dt = null)
@@ -198,6 +200,14 @@ namespace CmsData
                 ContactExtras.Add(ev);
             }
             return ev;
+        }
+
+        private static string RetrieveMetadata(string name, string value)
+        {
+            var extraValues = Views.GetStandardExtraValues(DbUtil.Db, "Contact");
+            var ev = extraValues.SingleOrDefault(x => x.Name == name);
+
+            return ev?.Codes.SingleOrDefault(x => x.Text == value)?.Metadata;
         }
     }
 }

--- a/CmsData/Extensions/Contact.cs
+++ b/CmsData/Extensions/Contact.cs
@@ -101,7 +101,7 @@ namespace CmsData
             return r;
         }
 
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;
@@ -110,7 +110,7 @@ namespace CmsData
             var ev = GetExtraValue(field);
             ev.StrValue = value;
             ev.TransactionTime = DateTime.Now;
-            ev.Metadata = RetrieveMetadata(field, value);
+            ev.Metadata = RetrieveMetadata(field, value, location);
         }
 
         public void AddEditExtraText(string field, string value, DateTime? dt = null)
@@ -202,9 +202,9 @@ namespace CmsData
             return ev;
         }
 
-        private static string RetrieveMetadata(string name, string value)
+        private static string RetrieveMetadata(string name, string value, string location)
         {
-            var extraValues = Views.GetStandardExtraValues(DbUtil.Db, "Contact");
+            var extraValues = Views.GetStandardExtraValues(DbUtil.Db, "Contact", false, location);
             var ev = extraValues.SingleOrDefault(x => x.Name == name);
 
             return ev?.Codes.SingleOrDefault(x => x.Text == value)?.Metadata;

--- a/CmsData/Extensions/Family.cs
+++ b/CmsData/Extensions/Family.cs
@@ -260,7 +260,7 @@ namespace CmsData
             ev.IntValue = value;
             ev.TransactionTime = DateTime.Now;
         }
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Extensions/Family.cs
+++ b/CmsData/Extensions/Family.cs
@@ -217,7 +217,7 @@ namespace CmsData
             DbUtil.LogActivity($"EVFamily {op}:{field}");
         }
 
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Extensions/Person.cs
+++ b/CmsData/Extensions/Person.cs
@@ -985,7 +985,7 @@ UPDATE dbo.GoerSenderAmounts SET SupporterId = {1} WHERE SupporterId = {0}", Peo
             DbUtil.LogActivity($"EV {op}:{field}", peopleid: PeopleId);
         }
 
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Extensions/Person.cs
+++ b/CmsData/Extensions/Person.cs
@@ -1037,7 +1037,7 @@ UPDATE dbo.GoerSenderAmounts SET SupporterId = {1} WHERE SupporterId = {0}", Peo
             ev.IntValue = value;
             ev.TransactionTime = Util.Now;
         }
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Meetings/Meeting.cs
+++ b/CmsData/Meetings/Meeting.cs
@@ -133,7 +133,7 @@ namespace CmsData
             ev.TransactionTime = DateTime.Now;
         }
 
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Meetings/Meeting.cs
+++ b/CmsData/Meetings/Meeting.cs
@@ -97,7 +97,7 @@ namespace CmsData
             return meeting;
         }
 
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Organization/Organization.cs
+++ b/CmsData/Organization/Organization.cs
@@ -478,7 +478,7 @@ namespace CmsData
             return GetExtra(db, OrganizationId, field);
         }
 
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Organization/Organization.cs
+++ b/CmsData/Organization/Organization.cs
@@ -514,7 +514,7 @@ namespace CmsData
             ev.TransactionTime = DateTime.Now;
         }
 
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -687,7 +687,7 @@ AND a.PeopleId = {2}
             ev.TransactionTime = DateTime.Now;
         }
 
-        public void AddEditExtraBool(string field, bool tf)
+        public void AddEditExtraBool(string field, bool tf, string name = null, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -651,7 +651,7 @@ AND a.PeopleId = {2}
                 return oev.IntValue.ToString();
             return oev.BitValue.ToString();
         }
-        public void AddEditExtraCode(string field, string value)
+        public void AddEditExtraCode(string field, string value, string location = null)
         {
             if (!field.HasValue())
                 return;

--- a/CmsWeb/Areas/People/Controllers/ContactController.cs
+++ b/CmsWeb/Areas/People/Controllers/ContactController.cs
@@ -119,13 +119,5 @@ namespace CmsWeb.Areas.People.Controllers
             var tid = m.AddTask(pid);
             return Redirect("/Task/" + tid);
         }
-        [HttpPost]
-        public ActionResult ExtraValues(int cid, string ministry, string contactType, string contactReason)
-        {
-            var m = new ContactModel(cid);
-            m.SetLocationOnContact(ministry, contactType, contactReason);
-            var evmodel = new ExtraValueModel(cid, "Contact", m.Location);
-            return View("/Views/ExtraValue/Location.cshtml", evmodel);
-        }
     }
 }

--- a/CmsWeb/Areas/People/Controllers/ContactController.cs
+++ b/CmsWeb/Areas/People/Controllers/ContactController.cs
@@ -1,5 +1,6 @@
 using System.Web.Mvc;
 using CmsWeb.Areas.People.Models;
+using CmsWeb.Models.ExtraValues;
 using UtilityExtensions;
 
 namespace CmsWeb.Areas.People.Controllers
@@ -117,6 +118,14 @@ namespace CmsWeb.Areas.People.Controllers
             var m = new ContacteesModel(cid);
             var tid = m.AddTask(pid);
             return Redirect("/Task/" + tid);
+        }
+        [HttpPost]
+        public ActionResult ExtraValues(int cid, int ministry, int contactType, int contactReason)
+        {
+            var m = new ContactModel(cid);
+            m.SetLocationOnContact(ministry, contactType, contactReason);
+            var evmodel = new ExtraValueModel(cid, "Contact", m.Location);
+            return View("/Views/ExtraValue/Location.cshtml", evmodel);
         }
     }
 }

--- a/CmsWeb/Areas/People/Controllers/ContactController.cs
+++ b/CmsWeb/Areas/People/Controllers/ContactController.cs
@@ -94,6 +94,7 @@ namespace CmsWeb.Areas.People.Controllers
         [HttpPost]
         public ActionResult ContactUpdate(int cid, ContactModel c)
         {
+            c.SetLocationOnContact();
             if (!ModelState.IsValid)
                 return View("ContactEdit", c);
             c.UpdateContact();

--- a/CmsWeb/Areas/People/Controllers/ContactController.cs
+++ b/CmsWeb/Areas/People/Controllers/ContactController.cs
@@ -120,7 +120,7 @@ namespace CmsWeb.Areas.People.Controllers
             return Redirect("/Task/" + tid);
         }
         [HttpPost]
-        public ActionResult ExtraValues(int cid, int ministry, int contactType, int contactReason)
+        public ActionResult ExtraValues(int cid, string ministry, string contactType, string contactReason)
         {
             var m = new ContactModel(cid);
             m.SetLocationOnContact(ministry, contactType, contactReason);

--- a/CmsWeb/Areas/People/Controllers/ContactController.cs
+++ b/CmsWeb/Areas/People/Controllers/ContactController.cs
@@ -15,10 +15,10 @@ namespace CmsWeb.Areas.People.Controllers
             if (m.contact == null)
                 return Content("contact is private or does not exist");
 
-            if( edit )
+            if (edit)
             {
                 TempData["ContactEdit"] = true;
-                return Redirect($"/Contact2/{cid}");                
+                return Redirect($"/Contact2/{cid}");
             }
             else
             {
@@ -118,6 +118,14 @@ namespace CmsWeb.Areas.People.Controllers
             var m = new ContacteesModel(cid);
             var tid = m.AddTask(pid);
             return Redirect("/Task/" + tid);
+        }
+        [HttpPost]
+        public ActionResult ExtraValues(int cid, string ministry, string contactType, string contactReason)
+        {
+            var m = new ContactModel(cid);
+            m.SetLocationOnContact(ministry, contactType, contactReason);
+            var evmodel = new ExtraValueModel(cid, "Contact", m.Location);
+            return View("/Views/ExtraValue/Location.cshtml", evmodel);
         }
     }
 }

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -149,6 +149,7 @@ namespace CmsWeb.Areas.People.Models
             cn.Execute(@"
                 delete contactees where ContactId = @cid;
                 delete contactors where ContactId = @cid;
+                delete contactextra where ContactId = @cid;
                 update task set CompletedContactId = NULL WHERE CompletedContactId = @cid;
                 update task set SourceContactId = NULL WHERE SourceContactId = @cid;
                 delete contact where ContactId = @cid;

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -44,6 +44,8 @@ namespace CmsWeb.Areas.People.Models
 
         public int? OrganizationId { get; set; }
 
+        public string Location { get; set; }
+
         public IEnumerable<SelectListItem> Roles()
         {
             var roles = DbUtil.Db.Setting("LimitToRolesForContacts", "").SplitStr(",").Where(rr => rr.HasValue()).ToArray();
@@ -119,6 +121,8 @@ namespace CmsWeb.Areas.People.Models
             LoadContact(id);
             if(contact != null)
                 this.CopyPropertiesFrom(contact);
+
+            SetLocationOnContact();
         }
 
         public bool CanView;
@@ -135,6 +139,7 @@ namespace CmsWeb.Areas.People.Models
 
             LoadContact(ContactId);
             this.CopyPropertiesTo(contact);
+            SetLocationOnContact();
             DbUtil.Db.SubmitChanges();
         }
         public static void DeleteContact(int cid)
@@ -213,6 +218,40 @@ namespace CmsWeb.Areas.People.Models
 
             return results;
         }
+
+        public void SetLocationOnContact()
+        {
+            var list = new List<int?>
+            {
+                Ministry.IntVal,
+                ContactType.IntVal,
+                ContactReason.IntVal,
+            };
+
+            Location = ComputeLocationString(list);
+        }
+
+        public void SetLocationOnContact(int? ministry, int? contactType, int? contactReason)
+        {
+            var list = new List<int?>
+            {
+                ministry,
+                contactType,
+                contactReason,
+            };
+
+            Location = ComputeLocationString(list);
+        }
+
+        private string ComputeLocationString(IEnumerable<int?> list)
+        {
+            list = list.Where(x => x != null && x != 0);
+            var location = string.Join("-", list);
+            if (location != string.Empty) return location;
+
+            return OrganizationId.HasValue ? "Organization" : "Person";
+        }
+
         private static ValidationResult ModelError(string message, string field)
         {
             return new ValidationResult(message, new[] { field });

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.Mvc;
 using CmsData;
@@ -222,35 +223,46 @@ namespace CmsWeb.Areas.People.Models
 
         public void SetLocationOnContact()
         {
-            var list = new List<int?>
+            var list = new List<string>
             {
-                Ministry.IntVal,
-                ContactType.IntVal,
-                ContactReason.IntVal,
+                Ministry.ToString(),
+                ContactType.ToString(),
+                ContactReason.ToString()
             };
 
             Location = ComputeLocationString(list);
         }
 
-        public void SetLocationOnContact(int? ministry, int? contactType, int? contactReason)
+        public void SetLocationOnContact(string ministry, string contactType, string contactReason)
         {
-            var list = new List<int?>
+            var list = new List<string>
             {
                 ministry,
                 contactType,
-                contactReason,
+                contactReason
             };
 
             Location = ComputeLocationString(list);
         }
 
-        private string ComputeLocationString(IEnumerable<int?> list)
+        private string ComputeLocationString(IEnumerable<string> list)
         {
-            list = list.Where(x => x != null && x != 0);
+            list = list.Where(x => x != null)
+                       .Select(SlugifyString);
             var location = string.Join("-", list);
             if (location != string.Empty) return location;
 
             return OrganizationId.HasValue ? "Organization" : "Person";
+        }
+
+        private string SlugifyString(string original)
+        {
+            // Replace all non-alphanumeric
+            var rgx = new Regex("[^a-zA-Z0-9]");
+            var slug = rgx.Replace(original, "");
+            var lowercaseSlug = slug.ToLower();
+
+            return lowercaseSlug;
         }
 
         private static ValidationResult ModelError(string message, string field)

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -248,21 +248,11 @@ namespace CmsWeb.Areas.People.Models
         private string ComputeLocationString(IEnumerable<string> list)
         {
             list = list.Where(x => x != null)
-                       .Select(SlugifyString);
+                       .Select(x => x.SlugifyString());
             var location = string.Join("-", list);
             if (location != string.Empty) return location;
 
             return OrganizationId.HasValue ? "Organization" : "Person";
-        }
-
-        private string SlugifyString(string original)
-        {
-            // Replace all non-alphanumeric
-            var rgx = new Regex("[^a-zA-Z0-9]");
-            var slug = rgx.Replace(original, "");
-            var lowercaseSlug = slug.ToLower();
-
-            return lowercaseSlug;
         }
 
         private static ValidationResult ModelError(string message, string field)

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -268,6 +268,8 @@ namespace CmsWeb.Areas.People.Models
             }
         }
 
+        public bool ShowDefaultCheckboxes => !DbUtil.Db.Setting("UX-HideContactCheckboxes");
+
         private string GetIncomplete()
         {
             if(contact == null)

--- a/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
+++ b/CmsWeb/Areas/People/Models/Contact/ContactModel.cs
@@ -59,7 +59,7 @@ namespace CmsWeb.Areas.People.Models
                 Selected = !string.IsNullOrWhiteSpace(LimitToRole) && LimitToRole == rolename
             }).ToList();
 
-            list.Insert(0, new SelectListItem { Value = "0", Text = "(not specified)", Selected = true});
+            list.Insert(0, new SelectListItem { Value = "0", Text = "(not specified)", Selected = true });
             return list;
         }
 
@@ -81,11 +81,11 @@ namespace CmsWeb.Areas.People.Models
             var list = DbUtil.Db.Organizations
                 .Where(x => string.IsNullOrEmpty(orgType) || orgType == x.OrganizationType.Description)
                 .OrderBy(r => r.OrganizationName).ToList().Select(x => new SelectListItem
-            {
-                Value = x.OrganizationId.ToString(),
-                Text = x.OrganizationName,
-                Selected = x.OrganizationId == OrganizationId
-            }).ToList();
+                {
+                    Value = x.OrganizationId.ToString(),
+                    Text = x.OrganizationName,
+                    Selected = x.OrganizationId == OrganizationId
+                }).ToList();
 
             list.Insert(0, new SelectListItem { Value = "0", Text = "(none)", Selected = true });
             return list;
@@ -98,9 +98,9 @@ namespace CmsWeb.Areas.People.Models
             var roles = u.UserRoles.Select(uu => uu.Role.RoleName.ToLower()).ToArray();
             var ManagePrivateContacts = HttpContext.Current.User.IsInRole("ManagePrivateContacts");
             var q = from c in DbUtil.Db.Contacts
-                   where (c.LimitToRole ?? "") == "" || roles.Contains(c.LimitToRole) || ManagePrivateContacts
-                   where c.ContactId == id
-                   select c;
+                    where (c.LimitToRole ?? "") == "" || roles.Contains(c.LimitToRole) || ManagePrivateContacts
+                    where c.ContactId == id
+                    select c;
             contact = q.SingleOrDefault();
             if (contact == null)
                 return;
@@ -120,7 +120,7 @@ namespace CmsWeb.Areas.People.Models
             : this()
         {
             LoadContact(id);
-            if(contact != null)
+            if (contact != null)
                 this.CopyPropertiesFrom(contact);
 
             SetLocationOnContact();
@@ -282,9 +282,11 @@ namespace CmsWeb.Areas.People.Models
 
         public bool ShowDefaultCheckboxes => !DbUtil.Db.Setting("UX-HideContactCheckboxes");
 
+        public bool ShowContactExtraFeature => DbUtil.Db.Setting("Feature-ContactExtra");
+
         private string GetIncomplete()
         {
-            if(contact == null)
+            if (contact == null)
                 LoadContact(ContactId);
             var sb = new StringBuilder();
             Append(Ministry.Value == "0", sb, "no ministry");

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
@@ -106,24 +106,20 @@ namespace CmsWeb.Areas.People.Models
                 case "last visit":
                     return HealthChecker.GetLastVisit(OrgId)?.ToShortDateString();
                 case "health":
-                    var groupHealth = HealthChecker.GetHealthMetric(OrgId);
-                    string spanColor;
-                    switch (groupHealth)
+                    var healthLabel = HealthChecker.GetHealthLabel(OrgId);
+                    switch (healthLabel.ToUpper())
                     {
-                        case MetricName.RED:
-                            spanColor = "alert-danger";
-                            break;
-                        case MetricName.YELLOW:
-                            spanColor = "alert-warning";
-                            break;
-                        case MetricName.GREEN:
-                            spanColor = "alert-success";
-                            break;
+                        case "RED":
+                            return $"<span class=\"text-center btn-block alert-danger\">{healthLabel}</span>";
+                        case "YELLOW":
+                            return $"<span class=\"text-center btn-block alert-warning\">{healthLabel}</span>";
+                        case "GREEN":
+                            return $"<span class=\"text-center btn-block alert-success\">{healthLabel}</span>";
+                        case "BRIGHT":
+                            return $"<span class=\"text-center btn-block\" style=\"background-color:LawnGreen \">{healthLabel}</span>";
                         default:
-                            spanColor = "alert-info";
-                            break;
+                            return string.Empty;
                     }
-                    return $"<span class=\"text-center btn-block {spanColor}\">{groupHealth.ToString()}</span>";
                 default:
                     if(_extraFields == null)
                         _extraFields = DbUtil.Db.LoadOrganizationById(OrgId)?.GetOrganizationExtras();

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using CmsData;
+using CmsData.Classes.HealthChecker;
 using CmsData.Classes.RoleChecker;
 using UtilityExtensions;
 
@@ -101,6 +102,25 @@ namespace CmsWeb.Areas.People.Models
                         return $"<button class=\"leave-org\" data-personid=\"{PeopleId}\" data-orgid=\"{OrgId}\">{column.Label}</button>";
                     else
                         return "";
+                case "health":
+                    var groupHealth = HealthChecker.GetHealthMetric(OrgId);
+                    string spanColor;
+                    switch (groupHealth)
+                    {
+                        case MetricName.RED:
+                            spanColor = "alert-danger";
+                            break;
+                        case MetricName.YELLOW:
+                            spanColor = "alert-warning";
+                            break;
+                        case MetricName.GREEN:
+                            spanColor = "alert-success";
+                            break;
+                        default:
+                            spanColor = "alert-info";
+                            break;
+                    }
+                    return $"<span class=\"text-center btn-block {spanColor}\">{groupHealth.ToString()}</span>";
                 default:
                     if(_extraFields == null)
                         _extraFields = DbUtil.Db.LoadOrganizationById(OrgId)?.GetOrganizationExtras();

--- a/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
+++ b/CmsWeb/Areas/People/Models/Person/Enrollments/OrgMemberInfo.cs
@@ -102,6 +102,9 @@ namespace CmsWeb.Areas.People.Models
                         return $"<button class=\"leave-org\" data-personid=\"{PeopleId}\" data-orgid=\"{OrgId}\">{column.Label}</button>";
                     else
                         return "";
+                case "lastvisit":
+                case "last visit":
+                    return HealthChecker.GetLastVisit(OrgId)?.ToShortDateString();
                 case "health":
                     var groupHealth = HealthChecker.GetHealthMetric(OrgId);
                     string spanColor;

--- a/CmsWeb/Areas/People/Views/Contact/ContactDisplay.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactDisplay.cshtml
@@ -1,10 +1,12 @@
 ﻿@using CmsData
+@using CmsWeb.Models.ExtraValues
 @using UtilityExtensions
 @model CmsWeb.Areas.People.Models.ContactModel
 @{
     var prewrap = Model.Ministry.ToString() == "TouchPoint Support" ? "" : "pre-wrap";
+    var evmodel = new ExtraValueModel(Model.ContactId, "Contact", Model.Location);
 }
-<form class="form ajax" method="post">
+<form class="form ajax" method="post" data-init="Editable" data-init2="ExtraEditable">
     @if (Model.Incomplete.HasValue())
     {
         <div class="alert alert-danger scrollToTop">
@@ -41,6 +43,13 @@
                         </dl>
                     }
                 </div>
+            </div>
+            <div class="row">
+                <div id="contact-extra-values" class="col-sm-12">
+                    @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+                </div>
+            </div>
+            <div class="row">
                 <div class="col-sm-12">
                     @if (Model.NotAtHome)
                     {

--- a/CmsWeb/Areas/People/Views/Contact/ContactDisplay.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactDisplay.cshtml
@@ -34,8 +34,8 @@
                     @Html.DisplayFor(m => m.ContactType)
                     @Html.DisplayFor(m => m.ContactReason)
                     @if (DbUtil.Db.Setting("UseContactVisitedOrgs") &&
-                        !DbUtil.Db.Setting("UX-ShowVisitedOrgInContactees") &&
-                        !string.IsNullOrWhiteSpace(Model.OrganizationName))
+                 !DbUtil.Db.Setting("UX-ShowVisitedOrgInContactees") &&
+                 !string.IsNullOrWhiteSpace(Model.OrganizationName))
                     {
                         <dl>
                             <dt>@DbUtil.Db.Setting("UX-VisitedOrgLabel", "Visited Organization")</dt>
@@ -44,11 +44,14 @@
                     }
                 </div>
             </div>
-            <div class="row">
-                <div id="contact-extra-values" class="col-sm-12">
-                    @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+            @if (Model.ShowContactExtraFeature)
+            {
+                <div class="row">
+                    <div id="contact-extra-values" class="col-sm-12">
+                        @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+                    </div>
                 </div>
-            </div>
+            }
             <div class="row">
                 <div class="col-sm-12">
                     @if (Model.NotAtHome)

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -83,31 +83,7 @@
         $(function () {
             $("select #OrganizationId").select2();
 
-            $('.code-dropdown select').each(function () {
-                var $this = $(this);
-                $this.on('change', function () {
-                    var data = {
-                        ministry: $('#Ministry_Value').val(),
-                        contactType: $('#ContactType_Value').val(),
-                        contactReason: $('#ContactReason_Value').val()
-                    };
-                    $.ajax({
-                        type: 'POST',
-                        url: '/Contact2/ExtraValues/@Model.ContactId',
-                        data: data,
-                        success: function (ret, status) {
-                            $.unblock();
-                            $('#contact-extra-values').empty();
-                            $('#contact-extra-values').append(ret);
-                            $.InitFunctions.ExtraEditable();
-                        },
-                        error: function (xhr, ajaxOptions, thrownError) {
-                            $.unblock();
-                            swal({title: "Error!", text: thrownError, type: "error", html: true});
-                        }
-                    });
-                });
-            });
+            WireUpExtraValues(@Model.ContactId);
         });
 
     </script>

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -1,12 +1,8 @@
 ﻿@using System.Web.Mvc.Html
 @using CmsData
-@using CmsData.Classes.RoleChecker
-@using CmsWeb.Models.ExtraValues
 @using UtilityExtensions
 @model CmsWeb.Areas.People.Models.ContactModel
-@{
-    var evmodel = new ExtraValueModel(Model.ContactId, "Contact", Model.Location);
-}
+
 <form id="edit-contact" class="form ajax" method="post" data-init="Editable" data-init2="ExtraEditable">
     @if (Model.Incomplete.HasValue())
     {
@@ -57,11 +53,6 @@
                 }
             </div>
             <div class="row">
-                <div id="contact-extra-values" class="col-sm-12">
-                    @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
-                </div>
-            </div>
-            <div class="row">
                 @if (Model.CanViewComments)
                 {
                     <div class="col-sm-12">
@@ -86,8 +77,6 @@
         // Index.cshtml will run this when it is being directly loaded into the DOM
         $(function () {
             $("select #OrganizationId").select2();
-
-            WireUpExtraValues(@Model.ContactId);
         });
 
     </script>

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -17,7 +17,7 @@
     @Html.HiddenFor(m => m.ContactId)
     @Html.HiddenFor(m => m.OrganizationId)
     <div class="box box-responsive">
-       <div class="box-content">
+        <div class="box-content">
             <div class="row">
                 <div class="col-sm-6">
                     @Html.EditorFor(m => m.ContactDate)
@@ -55,26 +55,29 @@
                     </div>
                 }
             </div>
-           <div class="row">
-               <div id="contact-extra-values" class="col-sm-12">
-                     @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
-                 </div>
-             </div>
-             <div class="row">
-               @if (Model.CanViewComments)
-               {
-                   <div class="col-sm-12">
-                       @Html.EditorFor(m => m.Comments, "TextArea")
-                       @Html.ValidationMessage("Comments")
-                   </div>
-               }
-           </div>
-            <br/>
+            @if (Model.ShowContactExtraFeature)
+            {
+                <div class="row">
+                    <div id="contact-extra-values" class="col-sm-12">
+                        @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+                    </div>
+                </div>
+            }
+            <div class="row">
+                @if (Model.CanViewComments)
+                {
+                    <div class="col-sm-12">
+                        @Html.EditorFor(m => m.Comments, "TextArea")
+                        @Html.ValidationMessage("Comments")
+                    </div>
+                }
+            </div>
+            <br />
             <a id="cancel" class="btn btn-default ajax" href="/Contact2/ContactDisplay/@Model.ContactId">Cancel</a>
             <a id="update" class="btn btn-primary ajax validate" href="/Contact2/ContactUpdate/@Model.ContactId">Update</a>
             @Html.ValidationMessage("contactors")
             @Html.ValidationMessage("contactees")
-            <br/><br/>
+            <br /><br />
         </div>
     </div>
 </form>
@@ -86,7 +89,10 @@
         $(function () {
             $("select #OrganizationId").select2();
 
-            WireUpExtraValues(@Model.ContactId);
+            @if (Model.ShowContactExtraFeature)
+            {
+                @:WireUpExtraValues(@Model.ContactId);
+            }
         });
 
     </script>

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -1,8 +1,12 @@
-﻿@using CmsData
+﻿@using System.Web.Mvc.Html
+@using CmsData
+@using CmsWeb.Models.ExtraValues
 @using UtilityExtensions
 @model CmsWeb.Areas.People.Models.ContactModel
-
-<form id="edit-contact" class="form ajax" method="post">
+@{
+    var evmodel = new ExtraValueModel(Model.ContactId, "Contact", Model.Location);
+}
+<form id="edit-contact" class="form ajax" method="post" data-init="Editable" data-init2="ExtraEditable">
     @if (Model.Incomplete.HasValue())
     {
         <div class="alert alert-danger scrollToTop">
@@ -39,7 +43,6 @@
                     </div>
                 </div>
                 <div class="col-sm-6">
-
                     @Html.EditorFor(m => m.NotAtHome)
                     @Html.EditorFor(m => m.LeftDoorHanger)
                     @Html.EditorFor(m => m.LeftMessage)
@@ -48,6 +51,13 @@
                     @Html.EditorFor(m => m.PrayerRequest)
                     @Html.EditorFor(m => m.GiftBagGiven)
                 </div>
+            </div>
+            <div class="row">
+                <div id="contact-extra-values" class="col-sm-12">
+                    @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+                </div>
+            </div>
+            <div class="row">
                 @if (Model.CanViewComments)
                 {
                     <div class="col-sm-12">
@@ -71,7 +81,34 @@
         // This only runs when the view is loaded over AJAX, otherwise jQuery won't be loaded
         // Index.cshtml will run this when it is being directly loaded into the DOM
         $(function () {
-            $("#OrganizationId").select2();
+            $("select #OrganizationId").select2();
+
+            $('.code-dropdown select').each(function () {
+                var $this = $(this);
+                $this.on('change', function () {
+                    var data = {
+                        ministry: $('#Ministry_Value').val(),
+                        contactType: $('#ContactType_Value').val(),
+                        contactReason: $('#ContactReason_Value').val()
+                    };
+                    $.ajax({
+                        type: 'POST',
+                        url: '/Contact2/ExtraValues/@Model.ContactId',
+                        data: data,
+                        success: function (ret, status) {
+                            $.unblock();
+                            $('#contact-extra-values').empty();
+                            $('#contact-extra-values').append(ret);
+                            $.InitFunctions.ExtraEditable();
+                        },
+                        error: function (xhr, ajaxOptions, thrownError) {
+                            $.unblock();
+                            swal({title: "Error!", text: thrownError, type: "error", html: true});
+                        }
+                    });
+                });
+            });
         });
+
     </script>
 }

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -43,7 +43,7 @@
                         </div>
                     </div>
                 </div>
-                @if (!RoleChecker.HasSetting(SettingName.Contact_HideDefaultCheckboxes, false))
+                @if (Model.ShowDefaultCheckboxes)
                 {
                     <div class="col-sm-6">
                         @Html.EditorFor(m => m.NotAtHome)

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -1,5 +1,6 @@
 ﻿@using System.Web.Mvc.Html
 @using CmsData
+@using CmsData.Classes.RoleChecker
 @using CmsWeb.Models.ExtraValues
 @using UtilityExtensions
 @model CmsWeb.Areas.People.Models.ContactModel
@@ -42,15 +43,18 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-sm-6">
-                    @Html.EditorFor(m => m.NotAtHome)
-                    @Html.EditorFor(m => m.LeftDoorHanger)
-                    @Html.EditorFor(m => m.LeftMessage)
-                    @Html.EditorFor(m => m.ContactMade)
-                    @Html.EditorFor(m => m.GospelShared)
-                    @Html.EditorFor(m => m.PrayerRequest)
-                    @Html.EditorFor(m => m.GiftBagGiven)
-                </div>
+                @if (!RoleChecker.HasSetting(SettingName.Contact_HideDefaultCheckboxes, false))
+                {
+                    <div class="col-sm-6">
+                        @Html.EditorFor(m => m.NotAtHome)
+                        @Html.EditorFor(m => m.LeftDoorHanger)
+                        @Html.EditorFor(m => m.LeftMessage)
+                        @Html.EditorFor(m => m.ContactMade)
+                        @Html.EditorFor(m => m.GospelShared)
+                        @Html.EditorFor(m => m.PrayerRequest)
+                        @Html.EditorFor(m => m.GiftBagGiven)
+                    </div>
+                }
             </div>
             <div class="row">
                 <div id="contact-extra-values" class="col-sm-12">

--- a/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/ContactEdit.cshtml
@@ -1,8 +1,11 @@
 ﻿@using System.Web.Mvc.Html
 @using CmsData
+@using CmsWeb.Models.ExtraValues
 @using UtilityExtensions
 @model CmsWeb.Areas.People.Models.ContactModel
-
+@{
+    var evmodel = new ExtraValueModel(Model.ContactId, "Contact", Model.Location);
+}
 <form id="edit-contact" class="form ajax" method="post" data-init="Editable" data-init2="ExtraEditable">
     @if (Model.Incomplete.HasValue())
     {
@@ -52,15 +55,20 @@
                     </div>
                 }
             </div>
-            <div class="row">
-                @if (Model.CanViewComments)
-                {
-                    <div class="col-sm-12">
-                        @Html.EditorFor(m => m.Comments, "TextArea")
-                        @Html.ValidationMessage("Comments")
-                    </div>
-                }
-            </div>
+           <div class="row">
+               <div id="contact-extra-values" class="col-sm-12">
+                     @Html.Partial("/Views/ExtraValue/Location.cshtml", evmodel)
+                 </div>
+             </div>
+             <div class="row">
+               @if (Model.CanViewComments)
+               {
+                   <div class="col-sm-12">
+                       @Html.EditorFor(m => m.Comments, "TextArea")
+                       @Html.ValidationMessage("Comments")
+                   </div>
+               }
+           </div>
             <br/>
             <a id="cancel" class="btn btn-default ajax" href="/Contact2/ContactDisplay/@Model.ContactId">Cancel</a>
             <a id="update" class="btn btn-primary ajax validate" href="/Contact2/ContactUpdate/@Model.ContactId">Update</a>
@@ -77,6 +85,8 @@
         // Index.cshtml will run this when it is being directly loaded into the DOM
         $(function () {
             $("select #OrganizationId").select2();
+
+            WireUpExtraValues(@Model.ContactId);
         });
 
     </script>

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -75,12 +75,11 @@
             });
         </script>
     }
-    else
-    {
-        <script>
-            $(function() {
-                $.InitFunctions.ExtraEditable();
-            });
-        </script>
-    }
+   <script>
+        $(function() {
+            $.InitFunctions.ExtraEditable();
+
+            WireUpExtraValues(@Model.ContactId);
+        });
+    </script>
 }

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -16,6 +16,12 @@
         .editableform .control-group {
             white-space: normal !important;
         }
+        label {
+            font-weight: normal !important;
+        }
+        label.control-label {
+            font-weight: bold !important;
+        }
     </style>
 }
 @Html.Hidden("Id")

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -1,28 +1,35 @@
 ﻿@model CmsWeb.Areas.People.Models.ContactModel
 @{
-  ViewBag.Title = "Contact";
-  ViewBag.PageHeader = "Contact";
-  Layout = ViewExtensions2.TouchPointLayout();
+    ViewBag.Title = "Contact";
+    ViewBag.PageHeader = "Contact";
+    Layout = ViewExtensions2.TouchPointLayout();
 }
 @section head
 {
     @Fingerprint.Css("/Content/touchpoint/lib/bootstrap-editable/css/bootstrap-editable.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2-bootstrap.css")
-    <style type="text/css">
-        .editable-checklist label {
-            white-space: normal !important;
-        }
-        .editableform .control-group {
-            white-space: normal !important;
-        }
-        label {
-            font-weight: normal !important;
-        }
-        label.control-label {
-            font-weight: bold !important;
-        }
-    </style>
+
+    @if (Model.ShowContactExtraFeature)
+    {
+        <style type="text/css">
+            .editable-checklist label {
+                white-space: normal !important;
+            }
+
+            .editableform .control-group {
+                white-space: normal !important;
+            }
+
+            label {
+                font-weight: normal !important;
+            }
+
+                label.control-label {
+                    font-weight: bold !important;
+                }
+        </style>
+    }
 }
 @Html.Hidden("Id")
 <div class="row tab-pane" data-action="GET">
@@ -84,16 +91,19 @@
     @if (ViewBag.edit)
     {
         <script>
-            $(function() {
+            $(function () {
                 $("select #OrganizationId").select2();
             });
         </script>
     }
-   <script>
+    <script>
         $(function() {
             $.InitFunctions.ExtraEditable();
 
-            WireUpExtraValues(@Model.ContactId);
+            @if (Model.ShowContactExtraFeature)
+            {
+                @:WireUpExtraValues(@Model.ContactId);
+            }
         });
     </script>
 }

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -6,11 +6,12 @@
 }
 @section head
 {
+    @Fingerprint.Css("/Content/touchpoint/lib/bootstrap-editable/css/bootstrap-editable.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2-bootstrap.css")
 }
 @Html.Hidden("Id")
-<div class="row">
+<div class="row tab-pane" data-action="GET">
     <div class="col-sm-12 col-md-9 col-lg-7">
         @(ViewBag.edit ? Html.Partial("ContactEdit", Model) : Html.Partial("ContactDisplay", Model))
         <ul class="nav nav-tabs" id="special-content-tabs">
@@ -63,13 +64,22 @@
 </div>
 @section scripts
 {
+    @Fingerprint.Script("/Content/touchpoint/lib/bootstrap-editable/js/bootstrap-editable.min.js")
     @Fingerprint.Script("/Content/touchpoint/js/people/contact.js")
     @Fingerprint.Script("/Content/touchpoint/lib/select2/js/select2.min.js")
     @if (ViewBag.edit)
     {
         <script>
-            $(function () {
-                $("#OrganizationId").select2();
+            $(function() {
+                $("select #OrganizationId").select2();
+            });
+        </script>
+    }
+    else
+    {
+        <script>
+            $(function() {
+                $.InitFunctions.ExtraEditable();
             });
         </script>
     }

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -92,6 +92,8 @@
    <script>
         $(function() {
             $.InitFunctions.ExtraEditable();
+
+            WireUpExtraValues(@Model.ContactId);
         });
     </script>
 }

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -9,6 +9,14 @@
     @Fingerprint.Css("/Content/touchpoint/lib/bootstrap-editable/css/bootstrap-editable.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2.css")
     @Fingerprint.Css("/Content/touchpoint/lib/select2/css/select2-bootstrap.css")
+    <style type="text/css">
+        .editable-checklist label {
+            white-space: normal !important;
+        }
+        .editableform .control-group {
+            white-space: normal !important;
+        }
+    </style>
 }
 @Html.Hidden("Id")
 <div class="row tab-pane" data-action="GET">

--- a/CmsWeb/Areas/People/Views/Contact/Index.cshtml
+++ b/CmsWeb/Areas/People/Views/Contact/Index.cshtml
@@ -92,8 +92,6 @@
    <script>
         $(function() {
             $.InitFunctions.ExtraEditable();
-
-            WireUpExtraValues(@Model.ContactId);
         });
     </script>
 }

--- a/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
+++ b/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
@@ -13,6 +13,12 @@
             @Model.HyperLink()
         </div>
     }
+    else if (Model.Type == "HTML")
+    {
+        <div class="col-sm-6">
+            @Html.Raw(Model.DisplayName)
+        </div>
+    }
     else
     {
         <div class="col-sm-6">

--- a/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
+++ b/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
@@ -34,9 +34,20 @@
                            data-name="@Model.DataName"
                            class="@Model.EditableClass"
                            data-url="@Model.EditUrl"
-                           @if (Model.Type == "Date") { <text> data-showbuttons="false" data-savenochange="true" </text> }
-                           @if (dv.HasValue()) { <text> data-value="@dv" </text> }
-                           @if (ds.HasValue()) { <text> data-source="@ds" </text> }>@Html.Raw(Model)</a>
+                           @if (Model.Type == "Date")
+                           {
+                               <text> data-showbuttons="false" data-savenochange="true" </text>
+                           }
+                           @if (dv.HasValue())
+                           {
+                               <text> data-value="@dv" </text>
+                           }
+                           @if (ds.HasValue())
+                           {
+                               <text> data-source="@ds" </text>
+                           }>
+                            @Html.Raw(Model)
+                        </a>
                     </div>
                 </div>
             }

--- a/CmsWeb/Areas/Search/Views/ContactSearch/Index.cshtml
+++ b/CmsWeb/Areas/Search/Views/ContactSearch/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model CmsWeb.Areas.Search.Models.ContactSearchModel
+﻿@using CmsData
+@model CmsWeb.Areas.Search.Models.ContactSearchModel
 @{
     ViewBag.Title = "Contact Search";
     ViewBag.PageHeader = "Contact Search";
@@ -36,7 +37,10 @@
                         @Html.EditorFor(m => m.SearchParameters.Ministry)
                     </div>
                     <div class="col-lg-4 col-md-5 col-sm-6">
-                        @Html.EditorFor(m => m.SearchParameters.ContactResult)
+                        @if (!DbUtil.Db.Setting("UX-HideContactCheckboxes"))
+                        {
+                            @Html.EditorFor(m => m.SearchParameters.ContactResult)
+                        }
                         <div class="form-group">
                             <label class="checkbox-inline control-label">
                                 @Html.CheckBoxFor(m => m.SearchParameters.Incomplete) Incomplete?

--- a/CmsWeb/Areas/Search/Views/ContactSearch/Results.cshtml
+++ b/CmsWeb/Areas/Search/Views/ContactSearch/Results.cshtml
@@ -1,4 +1,5 @@
-﻿@model CmsWeb.Areas.Search.Models.ContactSearchModel
+﻿@using CmsData
+@model CmsWeb.Areas.Search.Models.ContactSearchModel
 <div id="results">
     @Html.Partial("PagerTop", Model)
     <div class="table-responsive">
@@ -11,7 +12,10 @@
                     <th>Contactors</th>
                     <th>Contactees</th>
                     <th>Ministry</th>
-                    <th>Results</th>
+                    @if (!DbUtil.Db.Setting("UX-HideContactCheckboxes"))
+                    {
+                        <th>Results</th>
+                    }
                 </tr>
             </thead>
             <tbody>
@@ -24,7 +28,10 @@
                         <td>@c.ContactorList</td>
                         <td>@c.ContacteeList</td>
                         <td>@c.Ministry</td>
-                        <td>@c.Results</td>
+                        @if (!DbUtil.Db.Setting("UX-HideContactCheckboxes"))
+                        {
+                            <td>@c.Results</td>
+                        }
                     </tr>
                 }
             </tbody>

--- a/CmsWeb/Code/CodeValueModel.cs
+++ b/CmsWeb/Code/CodeValueModel.cs
@@ -362,6 +362,7 @@ namespace CmsWeb.Code
         public IEnumerable<CodeValueItem> ExtraValueTypeCodes()
         {
             yield return new CodeValueItem { Code = "Header", Value = "Header" };
+            yield return new CodeValueItem { Code = "HTML", Value = "HTML" };
             yield return new CodeValueItem { Code = "Link", Value = "Link" };
             yield return new CodeValueItem { Code = "Text", Value = "Text (single line)" };
             yield return new CodeValueItem { Code = "Text2", Value = "Text (multi line)" };

--- a/CmsWeb/Content/touchpoint/js/form-ajax.js
+++ b/CmsWeb/Content/touchpoint/js/form-ajax.js
@@ -87,7 +87,7 @@
     $("div.tab-pane").on("click", "a.ajax-refresh", function (event) {
         event.preventDefault();
         var d = $(this).closest("div.tab-pane");
-        $.formAjaxClick($(this), d.data("link"));
+        $.formAjaxClick($(this), d.data("link"), d.data("action"));
         return false;
     });
     $("body").on("click", "form.ajax a.ajax-refresh", function (event) {
@@ -165,7 +165,7 @@
         return false;
     });
 
-    $.formAjaxClick = function (a, link) {
+    $.formAjaxClick = function (a, link, action) {
         var $form = a.closest("form.ajax");
         var $load = $form;
         var $tabinit = $form.closest("div.tab-pane[data-init]");
@@ -187,6 +187,9 @@
             || $form[0].action
             || '#';
 
+        var type = action
+            || 'POST';
+
         if (a.data("size"))
             $("input[name='PageSize']", $form).val(a.data("size"));
         if (a.data("page"))
@@ -202,7 +205,7 @@
         if (!a.hasClass("validate") || $form.valid()) {
             var isModal = $load.hasClass("modal-form");
             $.ajax({
-                type: 'POST',
+                type: type,
                 url: url,
                 data: data,
                 beforeSend: function () {
@@ -213,6 +216,10 @@
                     $.unblock();
                 },
                 success: function (ret, status) {
+                    if (type === 'GET') {
+                        location.reload();
+                        return true;
+                    }
                     $.unblock();
                     if (a.data("redirect"))
                         window.location = ret;

--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -91,6 +91,10 @@ $(function () {
         return false;
     });
 
+    $.InitFunctions.Editable = function () {
+        $.InitFunctions.ExtraEditable();
+    };
+
 });
 
 function AddSelected(ret) {

--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -107,3 +107,31 @@ function AddSelected(ret) {
             break;
     }
 }
+
+function WireUpExtraValues(cid) {
+    $('.code-dropdown select').on('change', function () {
+        var data = {
+            ministry: $('#Ministry_Value').val(),
+            contactType: $('#ContactType_Value').val(),
+            contactReason: $('#ContactReason_Value').val()
+        };
+        $.ajax({
+            type: 'POST',
+            url: '/Contact2/ExtraValues/' + cid,
+            data: data,
+            beforeSend: function () {
+                $.block();
+            },
+            success: function (ret, status) {
+                $.unblock();
+                $('#contact-extra-values').empty();
+                $('#contact-extra-values').append(ret);
+                $.InitFunctions.ExtraEditable();
+            },
+            error: function (xhr, ajaxOptions, thrownError) {
+                $.unblock();
+                swal({ title: "Error!", text: thrownError, type: "error", html: true });
+            }
+        });
+    });
+}

--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -107,3 +107,31 @@ function AddSelected(ret) {
             break;
     }
 }
+
+function WireUpExtraValues(cid) {
+    $('.code-dropdown select').on('change', function () {
+        var data = {
+            ministry: $('#Ministry_Value option:selected').text(),
+            contactType: $('#ContactType_Value option:selected').text(),
+            contactReason: $('#ContactReason_Value option:selected').text()
+        };
+        $.ajax({
+            type: 'POST',
+            url: '/Contact2/ExtraValues/' + cid,
+            data: data,
+            beforeSend: function () {
+                $.block();
+            },
+            success: function (ret, status) {
+                $.unblock();
+                $('#contact-extra-values').empty();
+                $('#contact-extra-values').append(ret);
+                $.InitFunctions.ExtraEditable();
+            },
+            error: function (xhr, ajaxOptions, thrownError) {
+                $.unblock();
+                swal({ title: "Error!", text: thrownError, type: "error", html: true });
+            }
+        });
+    });
+}

--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -107,31 +107,3 @@ function AddSelected(ret) {
             break;
     }
 }
-
-function WireUpExtraValues(cid) {
-    $('.code-dropdown select').on('change', function () {
-        var data = {
-            ministry: $('#Ministry_Value option:selected').text(),
-            contactType: $('#ContactType_Value option:selected').text(),
-            contactReason: $('#ContactReason_Value option:selected').text()
-        };
-        $.ajax({
-            type: 'POST',
-            url: '/Contact2/ExtraValues/' + cid,
-            data: data,
-            beforeSend: function () {
-                $.block();
-            },
-            success: function (ret, status) {
-                $.unblock();
-                $('#contact-extra-values').empty();
-                $('#contact-extra-values').append(ret);
-                $.InitFunctions.ExtraEditable();
-            },
-            error: function (xhr, ajaxOptions, thrownError) {
-                $.unblock();
-                swal({ title: "Error!", text: thrownError, type: "error", html: true });
-            }
-        });
-    });
-}

--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -111,9 +111,9 @@ function AddSelected(ret) {
 function WireUpExtraValues(cid) {
     $('.code-dropdown select').on('change', function () {
         var data = {
-            ministry: $('#Ministry_Value').val(),
-            contactType: $('#ContactType_Value').val(),
-            contactReason: $('#ContactReason_Value').val()
+            ministry: $('#Ministry_Value option:selected').text(),
+            contactType: $('#ContactType_Value option:selected').text(),
+            contactReason: $('#ContactReason_Value option:selected').text()
         };
         $.ajax({
             type: 'POST',

--- a/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
+++ b/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
@@ -17,8 +17,8 @@ namespace CmsWeb.Controllers
             return View(location, m);
         }
 
-        [HttpPost, Route("ExtraValue/Edit/{table}/{type}")]
-        public ActionResult Edit(string table, string type, string pk, string name, string value)
+        [HttpPost, Route("ExtraValue/Edit/{table}/{location}/{type}")]
+        public ActionResult Edit(string table, string location, string type, string pk, string name, string value)
         {
             ExtraValueModel m;
             if(table == "OrgMember")
@@ -27,7 +27,7 @@ namespace CmsWeb.Controllers
                 m = new ExtraValueModel(a[0].ToInt(), a[1].ToInt(), table, "Adhoc");
             }
             else
-                m = new ExtraValueModel(pk.ToInt(), table);
+                m = new ExtraValueModel(pk.ToInt(), table, location);
             m.EditExtra(type, HttpUtility.UrlDecode(name), value);
             return new EmptyResult();
         }

--- a/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
+++ b/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
@@ -6,19 +6,19 @@ using UtilityExtensions;
 
 namespace CmsWeb.Controllers
 {
-    public partial class ExtraValueController 
+    public partial class ExtraValueController
     {
         [HttpPost, Route("ExtraValue/Display/{table}/{location}/{id}/{id2?}")]
         public ActionResult Display(string table, string location, int id, int? id2)
         {
             var m = table == "OrgMember"
-                ? new ExtraValueModel(id, id2 ?? 0, table, location) 
+                ? new ExtraValueModel(id, id2 ?? 0, table, location)
                 : new ExtraValueModel(id, table, location);
             return View(location, m);
         }
 
         [HttpPost, Route("ExtraValue/Edit/{table}/{location}/{type}")]
-        public ActionResult Edit(string table, string location, string type, string pk, string name, string value)
+        public ActionResult Edit(string table, string location, string type, string pk, string name, string[] value)
         {
             ExtraValueModel m;
             if(table == "OrgMember")

--- a/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
+++ b/CmsWeb/Controllers/ExtraValue/ExtraValueController.cs
@@ -32,17 +32,17 @@ namespace CmsWeb.Controllers
             return new EmptyResult();
         }
 
-        [HttpGet, Route("ExtraValue/Codes/{table}")]
-        public ActionResult Codes(string table, string name)
+        [HttpGet, Route("ExtraValue/Codes/{table}/{location}")]
+        public ActionResult Codes(string table, string name, string location)
         {
-            var m = new ExtraValueModel(table);
+            var m = new ExtraValueModel(table, location);
             return Content(m.CodesJson(HttpUtility.UrlDecode(name)));
         }
 
-        [HttpGet, Route("ExtraValue/Bits/{table}/{id:int}")]
-        public ActionResult Bits(string table, int id, string name)
+        [HttpGet, Route("ExtraValue/Bits/{table}/{location}/{id:int}")]
+        public ActionResult Bits(string table, int id, string name, string location)
         {
-            var m = new ExtraValueModel(id, table);
+            var m = new ExtraValueModel(id, table, location);
             return Content(m.DropdownBitsJson(HttpUtility.UrlDecode(name)));
         }
    }

--- a/CmsWeb/Controllers/ExtraValue/StandardController.cs
+++ b/CmsWeb/Controllers/ExtraValue/StandardController.cs
@@ -18,16 +18,15 @@ namespace CmsWeb.Controllers
         [HttpPost, Route("ExtraValue/EditStandard/{table}")]
         public ActionResult EditStandard(string table, int id, string location, string name)
         {
-            var m = new NewExtraValueModel(table, name);
-            m.Id = id;
-            m.ExtraValueLocation = location;
+            var m = new NewExtraValueModel(id, table, location);
+            m.ExtraValueName = name;
             return View(m);
         }
         [ValidateInput(false)]
         [HttpPost, Route("ExtraValue/SaveEditedStandard")]
         public ActionResult SaveEditedStandard(NewExtraValueModel m)
         {
-            var i = Views.GetViewsViewValue(DbUtil.Db, m.ExtraValueTable, m.ExtraValueName);
+            var i = Views.GetViewsViewValue(DbUtil.Db, m.ExtraValueTable, m.ExtraValueName, m.ExtraValueLocation);
             i.value.VisibilityRoles = m.VisibilityRoles;
             i.value.EditableRoles = m.EditableRoles;
             i.value.Codes = m.ConvertToCodes();
@@ -50,10 +49,10 @@ namespace CmsWeb.Controllers
             m.DeleteStandard(name, removedata);
             return Content("ok");
         }
-        [HttpPost, Route("ExtraValue/Delete/{table}/{id:int}")]
-        public ActionResult Delete(string table, int id, string name)
+        [HttpPost, Route("ExtraValue/Delete/{table}/{location}/{id:int}")]
+        public ActionResult Delete(string table, string location, int id, string name)
         {
-            var m = new ExtraValueModel(id, table, "Standard");
+            var m = new ExtraValueModel(id, table, location);
             m.Delete(name);
             return View("Standard", m);
         }

--- a/CmsWeb/Controllers/ExtraValue/StandardController.cs
+++ b/CmsWeb/Controllers/ExtraValue/StandardController.cs
@@ -15,6 +15,7 @@ namespace CmsWeb.Controllers
             var m = new NewExtraValueModel(id, table, location);
             return View(m);
         }
+        [ValidateInput(false)]
         [HttpPost, Route("ExtraValue/EditStandard/{table}")]
         public ActionResult EditStandard(string table, int id, string location, string name)
         {

--- a/CmsWeb/Controllers/ExtraValue/StandardController.cs
+++ b/CmsWeb/Controllers/ExtraValue/StandardController.cs
@@ -19,8 +19,7 @@ namespace CmsWeb.Controllers
         [HttpPost, Route("ExtraValue/EditStandard/{table}")]
         public ActionResult EditStandard(string table, int id, string location, string name)
         {
-            var m = new NewExtraValueModel(id, table, location);
-            m.ExtraValueName = name;
+            var m = new NewExtraValueModel(id, table, name, location);
             return View(m);
         }
         [ValidateInput(false)]

--- a/CmsWeb/Controllers/ExtraValue/StandardController.cs
+++ b/CmsWeb/Controllers/ExtraValue/StandardController.cs
@@ -42,6 +42,7 @@ namespace CmsWeb.Controllers
             return View(m);
         }
 
+        [ValidateInput(false)]
         [HttpPost, Route("ExtraValue/DeleteStandard/{table}/{location}")]
         public ActionResult DeleteStandard(string table, string location, string name, bool removedata)
         {
@@ -49,6 +50,7 @@ namespace CmsWeb.Controllers
             m.DeleteStandard(name, removedata);
             return Content("ok");
         }
+        [ValidateInput(false)]
         [HttpPost, Route("ExtraValue/Delete/{table}/{location}/{id:int}")]
         public ActionResult Delete(string table, string location, int id, string name)
         {

--- a/CmsWeb/Models/ExtraValue/ExtraValue.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValue.cs
@@ -55,6 +55,18 @@ namespace CmsWeb.Models.ExtraValues
             Id = v.OrganizationId;
             Model = model;
         }
+        public ExtraValue(ContactExtra v, ExtraValueModel model)
+        {
+            Type = v.Type;
+            Field = v.Field;
+            StrValue = v.StrValue;
+            DateValue = v.DateValue;
+            Data = v.Data;
+            IntValue = v.IntValue;
+            BitValue = v.BitValue;
+            Id = v.ContactId;
+            Model = model;
+        }
         public ExtraValue(MeetingExtra v, ExtraValueModel model)
         {
             Type = v.Type;

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -264,7 +264,7 @@ namespace CmsWeb.Models.ExtraValues
 
         public void EditExtra(string type, string name, string[] values)
         {
-            var value = values.First();
+            var value = values?.First();
 
             var record = TableObject();
             if (record == null)
@@ -303,7 +303,7 @@ namespace CmsWeb.Models.ExtraValues
                 case "Bits":
                 {
                     var existingBits = ExtraValueBits(name);
-                    var newCheckedBits = values;
+                    var newCheckedBits = values ?? new string[] {};
                     foreach (var currentBit in existingBits)
                     {
                         if (newCheckedBits.Contains(currentBit.Name))

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -107,6 +107,11 @@ namespace CmsWeb.Models.ExtraValues
                         where ee.PeopleId == Id2
                         select new ExtraValue(ee, this);
                     break;
+                case "Contact":
+                    q = from ee in DbUtil.Db.ContactExtras
+                        where ee.ContactId == Id
+                        select new ExtraValue(ee, this);
+                    break;
                 default:
                     q = new List<ExtraValue>();
                     break;
@@ -131,6 +136,8 @@ namespace CmsWeb.Models.ExtraValues
                     return DbUtil.Db.Families.SingleOrDefault(f => f.FamilyId == id);
                 case "OrgMember":
                     return DbUtil.Db.OrganizationMembers.SingleOrDefault(f => f.OrganizationId == id && f.PeopleId == id2);
+                case "Contact":
+                    return DbUtil.Db.LoadContactById(id);
                 default:
                     return null;
             }

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -186,13 +186,13 @@ namespace CmsWeb.Models.ExtraValues
 
         public Dictionary<string, string> Codes(string name)
         {
-            var f = Views.GetStandardExtraValues(DbUtil.Db, Table).Single(ee => ee.Name == name);
+            var f = Views.GetStandardExtraValues(DbUtil.Db, Table, false, Location).Single(ee => ee.Name == name);
             return f.Codes.ToDictionary(ee => ee.Text, ee => ee.Text);
         }
 
         public string CodesJson(string name)
         {
-            var f = Views.GetStandardExtraValues(DbUtil.Db, Table).Single(ee => ee.Name == name);
+            var f = Views.GetStandardExtraValues(DbUtil.Db, Table, false, Location).Single(ee => ee.Name == name);
             var q = from c in f.Codes
                     select new {value = c.Text, text = c.Text};
             return JsonConvert.SerializeObject(q.ToArray());
@@ -206,7 +206,7 @@ namespace CmsWeb.Models.ExtraValues
 
         private IEnumerable<AllBitsCheckedOrNot> ExtraValueBits(string name)
         {
-            var f = Views.GetStandardExtraValues(DbUtil.Db, Table).Single(ee => ee.Name == name);
+            var f = Views.GetStandardExtraValues(DbUtil.Db, Table, false, Location).Single(ee => ee.Name == name);
             var list = ListExtraValues().Where(pp => f.Codes.Select(x => x.Text).Contains(pp.Field)).ToList();
             var q = from c in f.Codes
                     join e in list on c.Text equals e.Field into j
@@ -221,7 +221,7 @@ namespace CmsWeb.Models.ExtraValues
 
         public string DropdownBitsJson(string name)
         {
-            var f = Views.GetStandardExtraValues(DbUtil.Db, Table).Single(ee => ee.Name == name);
+            var f = Views.GetStandardExtraValues(DbUtil.Db, Table, false, Location).Single(ee => ee.Name == name);
             var list = ListExtraValues().Where(pp => f.Codes.Select(x => x.Text).Contains(pp.Field)).ToList();
             var q = from c in f.Codes
                     join e in list on c.Text equals e.Field into j
@@ -236,7 +236,7 @@ namespace CmsWeb.Models.ExtraValues
 
         public string ListBitsJson(string name)
         {
-            var f = Views.GetStandardExtraValues(DbUtil.Db, Table).Single(ee => ee.Name == name);
+            var f = Views.GetStandardExtraValues(DbUtil.Db, Table, false, Location).Single(ee => ee.Name == name);
             var list = ListExtraValues().Where(pp => f.Codes.Select(x => x.Text).Contains(pp.Field)).ToList();
             var q = from c in f.Codes
                     join e in list on c.Text equals e.Field into j

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -308,7 +308,7 @@ namespace CmsWeb.Models.ExtraValues
                     {
                         if (newCheckedBits.Contains(currentBit.Name))
                             if (!currentBit.Checked)
-                                record.AddEditExtraBool(currentBit.Name, true);
+                                record.AddEditExtraBool(currentBit.Name, true, name, Location);
                         if (!newCheckedBits.Contains(currentBit.Name))
                             if (currentBit.Checked)
                                 RemoveExtraValue(record, currentBit.Name);

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -270,7 +270,7 @@ namespace CmsWeb.Models.ExtraValues
             switch (type)
             {
                 case "Code":
-                    record.AddEditExtraCode(name, value);
+                    record.AddEditExtraCode(name, value, Location);
                     break;
                 case "Data":
                 case "Text":
@@ -346,7 +346,7 @@ namespace CmsWeb.Models.ExtraValues
 
         public void DeleteStandard(string name, bool removedata)
         {
-            var i = Views.GetViewsViewValue(DbUtil.Db, Table, name);
+            var i = Views.GetViewsViewValue(DbUtil.Db, Table, name, Location);
             i.view.Values.Remove(i.value);
             i.views.Save(DbUtil.Db);
 
@@ -383,7 +383,7 @@ namespace CmsWeb.Models.ExtraValues
 
         public void SwitchMultiline(string name)
         {
-            var i = Views.GetViewsViewValue(DbUtil.Db, Table, name);
+            var i = Views.GetViewsViewValue(DbUtil.Db, Table, name, Location);
             i.value.Type = i.value.Type == "Text" ? "Text2" : "Text";
             i.views.Save(DbUtil.Db);
         }

--- a/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/ExtraValueModel.cs
@@ -262,8 +262,10 @@ namespace CmsWeb.Models.ExtraValues
             Log(record, "remove", name);
         }
 
-        public void EditExtra(string type, string name, string value)
+        public void EditExtra(string type, string name, string[] values)
         {
+            var value = values.First();
+
             var record = TableObject();
             if (record == null)
                 return;
@@ -301,8 +303,7 @@ namespace CmsWeb.Models.ExtraValues
                 case "Bits":
                 {
                     var existingBits = ExtraValueBits(name);
-                    value = HttpContext.Current.Request.Form["value[]"] ?? "";
-                    var newCheckedBits = value.Split(',');
+                    var newCheckedBits = values;
                     foreach (var currentBit in existingBits)
                     {
                         if (newCheckedBits.Contains(currentBit.Name))

--- a/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
@@ -168,6 +168,28 @@ namespace CmsWeb.Models.ExtraValues
             ExtraValueTable = table;
             ExtraValueLocation = location;
         }
+        public NewExtraValueModel(int id, string table, string name, string location)
+        {
+            var f = Views.GetStandardExtraValues(DbUtil.Db, table, false, location).Single(ee => ee.Name == name);
+            ExtraValueType = new CodeInfo(f.Type, "ExtraValueType");
+            Id = id;
+            ExtraValueName = name;
+            ExtraValueTable = table;
+            ExtraValueLocation = location;
+            VisibilityRoles = f.VisibilityRoles;
+            EditableRoles = f.EditableRoles;
+            ExtraValueLink = HttpUtility.HtmlDecode(f.Link);
+            var codes = string.Join("\n", f.Codes.Select(x => x.Text));
+            switch (ExtraValueType.Value)
+            {
+                case "Bits":
+                    ExtraValueCheckboxes = codes;
+                    break;
+                case "Code":
+                    ExtraValueCodes = codes;
+                    break;
+            }
+        }
         public NewExtraValueModel(int id, int id2, string table, string location)
         {
             ExtraValueType = new CodeInfo("Text", "ExtraValueType");

--- a/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
@@ -307,7 +307,7 @@ Option 2
         public string AddAsNewStandard()
         {
             ExtraValueName = ExtraValueName.Replace('/', '-');
-            var fields = Views.GetStandardExtraValues(DbUtil.Db, ExtraValueTable);
+            var fields = Views.GetStandardExtraValues(DbUtil.Db, ExtraValueTable, false, ExtraValueLocation);
             var existing = fields.SingleOrDefault(ff => ff.Name == ExtraValueName);
             if (existing != null)
                 throw new Exception($"{ExtraValueName} already exists");

--- a/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
@@ -24,7 +24,7 @@ namespace CmsWeb.Models.ExtraValues
         public string ExtraValueLocation { get; set; }
         public bool ClearOldValuesFirst { get; set; }
 
-        [DisplayName("Name"), StringLength(50), Required]
+        [DisplayName("Name"), Required]
         public string ExtraValueName { get; set; }
 
         [DisplayName("Type")]

--- a/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
+++ b/CmsWeb/Models/ExtraValue/NewExtraValueModel.cs
@@ -306,7 +306,8 @@ Option 2
 
         public string AddAsNewStandard()
         {
-            ExtraValueName = ExtraValueName.Replace('/', '-');
+            if (ExtraValueType.Value != "HTML")
+                ExtraValueName = ExtraValueName.Replace('/', '-');
             var fields = Views.GetStandardExtraValues(DbUtil.Db, ExtraValueTable, false, ExtraValueLocation);
             var existing = fields.SingleOrDefault(ff => ff.Name == ExtraValueName);
             if (existing != null)

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -139,7 +139,7 @@ namespace CmsWeb.Models.ExtraValues
                             where e.Id == Id
                             where Codes.Select(x => x.Text).Contains(e.Field)
                             select NoPrefix(e.Field);
-                    return string.Join("\n", q);
+                    return string.Join("<br /><br />", q);
                 }
                 case "Int":
                     return ev.IntValue.ToString2("d");

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -21,9 +21,9 @@ namespace CmsWeb.Models.ExtraValues
                 var n = HttpUtility.UrlEncode(Name);
                 var source = "";
                 if (Type == "Code" && Standard)
-                    source = $"/ExtraValue/Codes/{Model.Table}?name={n}";
+                    source = $"/ExtraValue/Codes/{Model.Table}/{Model.Location}?name={n}";
                 else if (Type == "Bits")
-                    source = $"/ExtraValue/Bits/{Model.Table}/{Id}?name={n}";
+                    source = $"/ExtraValue/Bits/{Model.Table}/{Model.Location}/{Id}?name={n}";
                 return source.HasValue() ? source : "";
             }
         }

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -137,7 +137,7 @@ namespace CmsWeb.Models.ExtraValues
                     var q = from e in Model.ListExtraValues()
                             where e.BitValue == true
                             where e.Id == Id
-                            where Codes.Contains(e.Field)
+                            where Codes.Select(x => x.Text).Contains(e.Field)
                             select NoPrefix(e.Field);
                     return string.Join("\n", q);
                 }

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -28,7 +28,7 @@ namespace CmsWeb.Models.ExtraValues
             }
         }
 
-        public string EditUrl => $"/ExtraValue/Edit/{Model.Table}/{Type}";
+        public string EditUrl => $"/ExtraValue/Edit/{Model.Table}/{Model.Location}/{Type}";
 
         public string DeleteUrl
         {
@@ -36,7 +36,7 @@ namespace CmsWeb.Models.ExtraValues
             {
                 var n = HttpUtility.UrlEncode(Name);
                 if (Model.Location != "Adhoc")
-                    return $"/ExtraValue/Delete/{Model.Table}/{Id}?name={n}";
+                    return $"/ExtraValue/Delete/{Model.Table}/{Model.Location}/{Id}?name={n}";
                 return $"/ExtraValue/DeleteAdhoc/{Model.Table}/{Id}?name={n}";
             }
         }

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -139,7 +139,9 @@ namespace CmsWeb.Models.ExtraValues
                             where e.Id == Id
                             where Codes.Select(x => x.Text).Contains(e.Field)
                             select NoPrefix(e.Field);
-                    
+
+                    if (q.ToList().Count == 0) return string.Empty;
+
                     var bullets = string.Join("</li><li>", q);
                     return "<ul><li>" + bullets + "</li></ul>";
                 }

--- a/CmsWeb/Models/ExtraValue/Value.cs
+++ b/CmsWeb/Models/ExtraValue/Value.cs
@@ -139,7 +139,9 @@ namespace CmsWeb.Models.ExtraValues
                             where e.Id == Id
                             where Codes.Select(x => x.Text).Contains(e.Field)
                             select NoPrefix(e.Field);
-                    return string.Join("<br /><br />", q);
+                    
+                    var bullets = string.Join("</li><li>", q);
+                    return "<ul><li>" + bullets + "</li></ul>";
                 }
                 case "Int":
                     return ev.IntValue.ToString2("d");

--- a/CmsWeb/Views/ExtraValue/EditStandard.cshtml
+++ b/CmsWeb/Views/ExtraValue/EditStandard.cshtml
@@ -4,7 +4,7 @@
 <div class="modal-dialog">
     <div class="modal-content">
         <div class="modal-header">
-            <a class="ajax close" href="/ExtraValue/ListStandard/@Model.ExtraValueTable/Standard/@Model.Id"><span aria-hidden="true">&times;</span></a>
+            <a class="ajax close" href="/ExtraValue/ListStandard/@Model.ExtraValueTable/@Model.ExtraValueLocation/@Model.Id"><span aria-hidden="true">&times;</span></a>
             <h4 class="modal-title">Edit Standard Extra Value</h4>
         </div>
         <div class="modal-body">
@@ -52,7 +52,7 @@
             }
         </div>
         <div class="modal-footer">
-            <a href="/ExtraValue/ListStandard/@Model.ExtraValueTable/Standard/@Model.Id" class="ajax btn btn-default">Cancel</a>
+            <a href="/ExtraValue/ListStandard/@Model.ExtraValueTable/@Model.ExtraValueLocation/@Model.Id" class="ajax btn btn-default">Cancel</a>
             <a href="/ExtraValue/SaveEditedStandard" class="save btn btn-primary ajax validate" data-callback="EditStandardExtraValueDialogCallback">Save</a>
         </div>
     </div>

--- a/CmsWeb/Views/ExtraValue/ListStandard.cshtml
+++ b/CmsWeb/Views/ExtraValue/ListStandard.cshtml
@@ -23,7 +23,7 @@
                     <tbody>
                         @foreach (var f in Model.GetStandardExtraValuesWithDataType(Model.Table, Model.Location))
                         {
-                            <tr id="ev-name-@f.Name.Replace(' ', '_')">
+                            <tr id="ev-name-@f.Name.SlugifyString()">
                                 <td style="width: 85px;"><input type="number" name="orders[@f.Name]" value="@f.Order" class="form-control" /></td>
                                 <td>@f.Name</td>
                                 <td>
@@ -39,7 +39,7 @@
                                     <a href="/ExtraValue/EditStandard/@Model.Table?location=@Model.Location&name=@Server.UrlEncode(f.Name)" class="ajax btn btn-default btn-sm"><i class="fa fa-pencil"></i> Edit</a>
                                 </td>
                                 <td style="width: 50px;">
-                                    <a href="/ExtraValue/DeleteStandard/@Model.Table/@Model.Location?name=@Server.UrlEncode(f.Name)" data-rowid="#ev-name-@f.Name.Replace(' ','_')" class="btn btn-danger btn-sm delete-extra-value" title="Delete Standard Extra Value: @f.Name"><i class="fa fa-trash"></i> Delete</a> 
+                                    <a href="/ExtraValue/DeleteStandard/@Model.Table/@Model.Location?name=@Server.UrlEncode(f.Name)" data-rowid="#ev-name-@f.Name.SlugifyString()" class="btn btn-danger btn-sm delete-extra-value" title="Delete Standard Extra Value: @f.Name"><i class="fa fa-trash"></i> Delete</a> 
                                 </td>
                             </tr>
                         }

--- a/UtilityExtensions/Extensions/StringExtensions.cs
+++ b/UtilityExtensions/Extensions/StringExtensions.cs
@@ -303,6 +303,7 @@ namespace UtilityExtensions
             s = Regex.Replace(s, "<style type=\"text/css\">._44eb54-hoverMenu.*?</style>", "", RegexOptions.Singleline);
             return Regex.Replace(s, @"\sdata-gramm\w*?="".*?""", "", RegexOptions.Singleline);
         }
+
         public static string Md5Hash(this string s)
         {
             var md5 = MD5.Create();
@@ -312,6 +313,16 @@ namespace UtilityExtensions
             foreach (var t in hash)
                 sb.Append(t.ToString("x2"));
             return sb.ToString();
+		}
+		
+        public static string SlugifyString(this string original)
+        {
+            // Replace all non-alphanumeric
+            var rgx = new Regex("[^a-zA-Z0-9]");
+            var slug = rgx.Replace(original, "");
+            var lowercaseSlug = slug.ToLower();
+
+            return lowercaseSlug;
         }
     }
 }


### PR DESCRIPTION
This pull request adds extra value support to the contacts. The backing table is `ContactExtra`, which was recently added. One distinction with contacts is that the location is based on the ministry, contact type and contact reason.

Finally, this feature is hidden behind an admin setting named `Feature-ContactExtra`.