### PR TITLE
Fix issue with multiline extra value display (#120)

### DIFF
--- a/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
+++ b/CmsWeb/Areas/People/Views/Shared/EditorTemplates/Value.cshtml
@@ -34,20 +34,9 @@
                            data-name="@Model.DataName"
                            class="@Model.EditableClass"
                            data-url="@Model.EditUrl"
-                           @if (Model.Type == "Date")
-                           {
-                               <text> data-showbuttons="false" data-savenochange="true" </text>
-                           }
-                           @if (dv.HasValue())
-                           {
-                               <text> data-value="@dv" </text>
-                           }
-                           @if (ds.HasValue())
-                           {
-                               <text> data-source="@ds" </text>
-                           }>
-                            @Html.Raw(Model)
-                        </a>
+                           @if (Model.Type == "Date") { <text> data-showbuttons="false" data-savenochange="true" </text> }
+                           @if (dv.HasValue()) { <text> data-value="@dv" </text> }
+                           @if (ds.HasValue()) { <text> data-source="@ds" </text> }>@Html.Raw(Model)</a>
                     </div>
                 </div>
             }


### PR DESCRIPTION
White space is usually *not* significant in HTML, but it is if `white-space: pre-wrap` is used. I wouldn't be surprised if some auto formatter even did this. Sorry we missed this!

This will fix https://clearfunction.sifterapp.com/issues/904.