### PR TITLE
Fix javascript case sensitivity issue

### DIFF
--- a/CmsWeb/Content/touchpoint/js/people/contact.js
+++ b/CmsWeb/Content/touchpoint/js/people/contact.js
@@ -113,7 +113,7 @@ function WireUpExtraValues(cid, locations) {
         return;
 
     function sameStr(left, right) {
-        return left.localeCompare(right, undefined, { sensitivity: 'case' }) === 0;
+        return left.localeCompare(right, undefined, { sensitivity: 'base' }) === 0;
     }
 
     function valueMatches(left, right) {


### PR DESCRIPTION
I misread the `localeCompare` docs on this... it should `base`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare for details.

Sorry about that.