### PR TITLE
Fix Condition ContributionAmountSinceSetting

### DIFF
--- a/CmsData/QueryBuilder/Expressions/Contributions.cs
+++ b/CmsData/QueryBuilder/Expressions/Contributions.cs
@@ -302,7 +302,7 @@ namespace CmsData
         }
         internal Expression ContributionAmountSinceSetting()
         {
-        	var re = new Regex(@"(?<name>[^,]*)(,\s*(?<fundid>\d+))?");
+        	var re = new Regex(@"(?<name>[^,]*)(,\s*(?<fundid>.+))?");
         	var m = re.Match(Quarters);
     		var name = m.Groups["name"].Value;
     		var fundid = m.Groups["fundid"].Value;


### PR DESCRIPTION
This should fix the problem with MountPisgah Recent Donors not reconciling.
It was a bug in the regular expression to split the values in the Setting Name (with start date).
They have a second parameter to fetch the fundid separated by a comma.
`BridgeSinceDate,BridgeFundId`
Both of these names are for settings in their database.
The second name was returning an empty fundid because of the regex bug.

Trello: Bridge+ Discrepancy when running script reports https://trello.com/c/O8rvfZmp
Please let me know when this is published so that I can let Jeannie know.