### PR TITLE
Austin more scoped finance reports

### DIFF
--- a/CmsWeb/Areas/Reports/Controllers/ExportController.cs
+++ b/CmsWeb/Areas/Reports/Controllers/ExportController.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Web.Mvc;
 using CmsData;
 using CmsWeb.Areas.Reports.Models;
 using CmsWeb.Areas.Search.Models;
@@ -11,6 +5,12 @@ using CmsWeb.Models;
 using Dapper;
 using MoreLinq;
 using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Web.Mvc;
 using UtilityExtensions;
 
 namespace CmsWeb.Areas.Reports.Controllers
@@ -40,7 +40,7 @@ namespace CmsWeb.Areas.Reports.Controllers
             return MembershipExportModel.MembershipInfoList(id);
         }
 
-        [Authorize(Roles = "Finance")]
+        [Authorize(Roles = "Finance,FinanceViewOnly")]
         [HttpPost]
         public ActionResult Contributions(string id, ContributionsExcelResult m)
         {
@@ -59,19 +59,19 @@ namespace CmsWeb.Areas.Reports.Controllers
                 startdate = dt1,
                 enddate = dt2,
             }, commandType: CommandType.StoredProcedure, commandTimeout: 600);
-            var entity = (IDictionary<string, object>) q.First();
+            var entity = (IDictionary<string, object>)q.First();
             var cols = entity.Keys.Cast<string>().ToList();
             var ep = new ExcelPackage();
             var ws = ep.Workbook.Worksheets.Add("Sheet1");
             int row = 1;
             for (var i = 0; i < cols.Count; i++)
-                ws.Cells[row, i+1].Value = cols[i];
+                ws.Cells[row, i + 1].Value = cols[i];
             row++;
             foreach (var r in q)
             {
-                var rr = (IDictionary<string, object>) r;
+                var rr = (IDictionary<string, object>)r;
                 for (var i = 0; i < cols.Count; i++)
-                    ws.Cells[row, i+1].Value = rr[cols[i]];
+                    ws.Cells[row, i + 1].Value = rr[cols[i]];
                 row++;
             }
             ws.Cells[ws.Dimension.Address].AutoFitColumns();
@@ -91,7 +91,7 @@ namespace CmsWeb.Areas.Reports.Controllers
         [HttpPost]
         public ActionResult OrgDayStats(DateTime? dt, OrgSearchModel m)
         {
-            if(!dt.HasValue)
+            if (!dt.HasValue)
                 dt = ChurchAttendanceModel.MostRecentAttendedSunday();
             var orgs = string.Join(",", m.FetchOrgs().Select(oo => oo.OrganizationId));
             var q = DbUtil.Db.OrgDayStats(orgs, dt);
@@ -109,7 +109,7 @@ namespace CmsWeb.Areas.Reports.Controllers
         [Route("Excel/{format}/{id:guid}")]
         public ActionResult Excel(Guid id, string format, bool? titles, bool? useMailFlags)
         {
-            var ctl = new MailingController {UseTitles = titles ?? false, UseMailFlags = useMailFlags ?? false};
+            var ctl = new MailingController { UseTitles = titles ?? false, UseMailFlags = useMailFlags ?? false };
             switch (format)
             {
                 case "Individual":
@@ -154,7 +154,7 @@ namespace CmsWeb.Areas.Reports.Controllers
         [HttpGet]
         public ActionResult Csv(Guid id, string format, bool? sortzip, bool? titles, bool? useMailFlags)
         {
-            var ctl = new MailingController {UseTitles = titles ?? false, UseMailFlags = useMailFlags ?? false};
+            var ctl = new MailingController { UseTitles = titles ?? false, UseMailFlags = useMailFlags ?? false };
 
             var sort = "Name";
             if (sortzip ?? false)

--- a/CmsWeb/Views/Shared/Menu/Admin.cshtml
+++ b/CmsWeb/Views/Shared/Menu/Admin.cshtml
@@ -74,7 +74,7 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <span class="visible-xs-inline"><i class="fa fa-cogs"></i>&nbsp;&nbsp;</span><span class="hidden-lg hidden-xs">Admin</span><span class="visible-lg-inline visible-xs-inline">Administration</span> <b class="caret"></b>
             </a>
-            if (admin || manageemails || managetrans || edit || design || manageResources || financedataentry)
+            if (admin || manageemails || managetrans || edit || design || manageResources || financedataentry || financeviewonly)
             {
                 <ul id="admin-menu-col-1" class="dropdown-menu dropdown-menu-large row">
                     <li class="col-sm-4">

--- a/CmsWeb/Views/Shared/Menu/Admin.cshtml
+++ b/CmsWeb/Views/Shared/Menu/Admin.cshtml
@@ -81,6 +81,7 @@
                         <ul>
                             <li class="dropdown-header dropdown-sub-header">Contributions</li>
                             @Helper.LiAnchorLink("Deposits Totals", "/FinanceReports/DepositTotalsForDates/")
+                            @Helper.LiAnchorLink("Totals by Fund", "/FinanceReports/TotalsByFund/")
                             <li class="dropdown-header dropdown-sub-header">Reports</li>
                             <li>
                                 <a href='/FinanceReports/DonorTotalSummary' class="dialog-options" data-target="/FinanceReports/DonorTotalSummaryOptions">Donor Total Summary Export</a>
@@ -112,6 +113,7 @@
                         <ul>
                             <li class="dropdown-header dropdown-sub-header">Contributions</li>
                             @Helper.LiAnchorLink("Deposits Totals", "/FinanceReports/DepositTotalsForDates/")
+                            @Helper.LiAnchorLink("Totals by Fund", "/FinanceReports/TotalsByFund/")
                             <li class="dropdown-header dropdown-sub-header">Reports</li>
                             <li>
                                 <a href='/FinanceReports/DonorTotalSummary' class="dialog-options" data-target="/FinanceReports/DonorTotalSummaryOptions">Donor Total Summary Export</a>


### PR DESCRIPTION
Current Problems:
1. Total by Funds report set does not appear in the menu.
Added menu option, before this was only viewable to the Finance role, but nothing prevented direct navigation to it.

2. The Giving tab on People records is not seen. (This was specifically requested by the client. Should see only designated fund(s) on the Giving tab; should not see non-allowed funds, nor Statements that include all funds.)
Added filters for the contributions that make up the statement and the giving tab based on role membership. The current user can view their own page and see everything or an authorized user clicking on the giving tab would see only those contributions that were to a fund they are authorized for. This has a side effect of meaning that 2 users could see different balances for a statement if they are authorized for different funds.

3. No ability to export any reports. (Takes me to the login screen.)
Corrected the roles for this controller method and you can now export.

4. The Contributions Basics Report includes non-allowed funds.
Custom report at client level. Goal is to remove custom reports from the menu if not a member of the finance role. 

5. The Monthly Giving Analysis includes non-allowed funds.
Custom report at client level. Goal is to remove custom reports from the menu if not a member of the finance role. 

6. Totals by Funds Payment Type includes non-allowed funds.
Custom report at client level. Goal is to remove custom reports from the menu if not a member of the finance role. 
