### PR TITLE
Improve deceased person highlighted elements

### DIFF
--- a/CmsWeb/Areas/People/Views/Person/DisplayTemplates/DeceasedDate.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/DisplayTemplates/DeceasedDate.cshtml
@@ -2,5 +2,5 @@
 @model DateTime?
 <dl>
     <dt>@Html.DisplayNameFor(m => m)</dt>
-    <dd class="@(Model.HasValue ? "alert alert-danger" : "" )">@Model.FormatDate()</dd>
+    <dd class="@(Model.HasValue ? "alert-danger" : "" )">@Model.FormatDate()</dd>
 </dl>

--- a/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Family/Members.cshtml
@@ -37,7 +37,7 @@
                 @foreach (var m in Model.ViewList())
                 {
                     var active = m.Id == Model.Person.PeopleId ? "active" : "";
-                    var ifdeceased = !active.HasValue() && m.IsDeceased == true ? "alert alert-danger" : "";
+                    var ifdeceased = !active.HasValue() && m.IsDeceased == true ? "alert-danger" : "";
                     var picdt = (m.PicDate ?? DateTime.Now);
                     var portraitUrl = $"/Portrait/{m.PortraitId}?v={picdt.Ticks}";
                     var portraitBgPos = m.PicXPos.HasValue || m.PicYPos.HasValue ? $"{m.PicXPos ?? 0}% {m.PicYPos ?? 0}%" : "top";


### PR DESCRIPTION
Deceased people are highlighted in red but in some areas the css added extra padding unnecessarily
![before](https://user-images.githubusercontent.com/2912683/44541649-3d7fe380-a6d0-11e8-9681-796eae707702.PNG)
![after](https://user-images.githubusercontent.com/2912683/44541651-3d7fe380-a6d0-11e8-8e6c-3630927138cf.PNG)
