### PR TITLE
Fix for accessing DbUtil.Db outside of an HttpContext thread

### DIFF
--- a/CmsData/Classes/CMSRoleProvider.cs
+++ b/CmsData/Classes/CMSRoleProvider.cs
@@ -102,17 +102,22 @@ namespace CmsData
 		public IEnumerable<Person> GetDevelopers()
 		{
 			return GetRoleUsers("Developer").Select(u => u.Person);
-		}
+        }
 
-		public override bool IsUserInRole(string username, string rolename)
-		{
+        public bool IsUserInRole(string username, string rolename, CMSDataContext db)
+        {
 			username = Util.GetUserName(username);
-			var q = from ur in DbUtil.Db.UserRoles
+			var q = from ur in db.UserRoles
 					where rolename == ur.Role.RoleName
 					where username == ur.User.Username
 					select ur;
 			return q.Count() > 0;
-		}
+        }
+
+        public override bool IsUserInRole(string username, string rolename)
+        {
+            return IsUserInRole(username, rolename, DbUtil.Db);
+        }
 
 		public override void RemoveUsersFromRoles(string[] usernames, string[] rolenames)
 		{

--- a/CmsData/DbUtil/DbUtil.cs
+++ b/CmsData/DbUtil/DbUtil.cs
@@ -91,31 +91,6 @@ namespace CmsData
                 db.ActivityLogs.InsertOnSubmit(a);
                 db.SubmitChanges();
             }
-
-            // Logging temporarily to monitor some major changes
-
-            //            if (!a.Activity.StartsWith("OnlineReg"))
-            //                return;
-            //
-            //            var cs = ConfigurationManager.ConnectionStrings["CmsLogging"];
-            //            if (cs != null)
-            //            {
-            //                using (var cn = new SqlConnection(cs.ConnectionString))
-            //                {
-            //                    cn.Open();
-            //                    cn.Execute(
-            //                        "INSERT dbo.RegActivity (db, dt, activity, oid, pid, did) VALUES(@db, @dt, @ac, @oid, @pid, @did)",
-            //                        new
-            //                        {
-            //                            db = host,
-            //                            ac = activity,
-            //                            dt = a.ActivityDate,
-            //                            oid = a.OrgId,
-            //                            pid = a.PeopleId,
-            //                            did = a.DatumId,
-            //                        });
-            //                }
-            //            }
         }
 
         public static void LogActivity(string activity, int? orgid = null, int? peopleid = null, int? datumId = null, int? userId = null, string pageUrl = null, string clientIp = null)

--- a/CmsData/DbUtil/DbUtil.cs
+++ b/CmsData/DbUtil/DbUtil.cs
@@ -19,15 +19,23 @@ namespace CmsData
     public static partial class DbUtil
     {
         private const string CMSDbKEY = "CMSDbKey";
+        private static CMSDataContext _InternalDb = null;
         private static CMSDataContext InternalDb
         {
             get
             {
-                return (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
+                return _InternalDb ?? (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
             }
             set
             {
-                HttpContext.Current.Items[CMSDbKEY] = value;
+                if (HttpContext.Current == null)
+                {
+                    _InternalDb = value;
+                }
+                else
+                {
+                    HttpContext.Current.Items[CMSDbKEY] = value;
+                }
             }
         }
 
@@ -35,14 +43,7 @@ namespace CmsData
         {
             get
             {
-                if (HttpContext.Current == null)
-                    return CMSDataContext.Create(Util.ConnectionString, Util.Host);
-                if (InternalDb == null)
-                {
-                    InternalDb = CMSDataContext.Create(Util.ConnectionString, Util.Host);
-                    InternalDb.CommandTimeout = 1200;
-                }
-                return InternalDb;
+                return InternalDb ?? (InternalDb = CMSDataContext.Create(Util.ConnectionString, Util.Host));
             }
             set
             {
@@ -58,7 +59,7 @@ namespace CmsData
 
         public static CMSDataContext Create(string connstr, string host)
         {
-            return CMSDataContext.Create(connstr, host);
+            return (InternalDb = CMSDataContext.Create(connstr, host));
         }
 
         private static void _logActivity(string host, string activity, int? orgId, int? peopleId, int? datumId, int? userId, string pageUrl = null, string clientIp = null)

--- a/CmsData/DbUtil/DbUtil.cs
+++ b/CmsData/DbUtil/DbUtil.cs
@@ -20,17 +20,22 @@ namespace CmsData
     {
         private const string CMSDbKEY = "CMSDbKey";
 
+        private static CMSDataContext _InternalDb;
         private static CMSDataContext InternalDb
         {
             get
             {
-                return (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
+                return _InternalDb ?? (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
             }
             set
             {
                 if (HttpContext.Current != null)
                 {
                     HttpContext.Current.Items[CMSDbKEY] = value;
+                }
+                else
+                {
+                    _InternalDb = value;
                 }
             }
         }

--- a/CmsData/DbUtil/DbUtil.cs
+++ b/CmsData/DbUtil/DbUtil.cs
@@ -19,20 +19,16 @@ namespace CmsData
     public static partial class DbUtil
     {
         private const string CMSDbKEY = "CMSDbKey";
-        private static CMSDataContext _InternalDb = null;
+
         private static CMSDataContext InternalDb
         {
             get
             {
-                return _InternalDb ?? (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
+                return (CMSDataContext)HttpContext.Current.Items[CMSDbKEY];
             }
             set
             {
-                if (HttpContext.Current == null)
-                {
-                    _InternalDb = value;
-                }
-                else
+                if (HttpContext.Current != null)
                 {
                     HttpContext.Current.Items[CMSDbKEY] = value;
                 }
@@ -54,7 +50,7 @@ namespace CmsData
 
         public static CMSDataContext Create(string host)
         {
-            return CMSDataContext.Create(Util.GetConnectionString(host), host);
+            return (InternalDb = CMSDataContext.Create(Util.GetConnectionString(host), host));
         }
 
         public static CMSDataContext Create(string connstr, string host)

--- a/CmsData/DbUtil/Session2.cs
+++ b/CmsData/DbUtil/Session2.cs
@@ -105,7 +105,7 @@ namespace CmsData
             {
                 try
                 {
-                    list = Settings.ToDictionary(c => c.Id.Trim(), c => c.SettingX,
+                    list = Settings.ToList().ToDictionary(c => c.Id.Trim(), c => c.SettingX,
                         StringComparer.OrdinalIgnoreCase);
                     HttpRuntime.Cache.Insert(Host + "Setting", list, null,
                         DateTime.Now.AddSeconds(15), Cache.NoSlidingExpiration);

--- a/CmsWeb/Areas/Finance/Models/ContributionStatementResult.cs
+++ b/CmsWeb/Areas/Finance/Models/ContributionStatementResult.cs
@@ -48,7 +48,7 @@ namespace CmsWeb.Areas.Finance.Models.Report
             var response = context.HttpContext.Response;
             response.ContentType = "application/pdf";
             response.AddHeader("content-disposition", "filename=foo.pdf");
-            var cs = ContributionStatements.GetStatementSpecification(statementType ?? "all");
+            var cs = ContributionStatements.GetStatementSpecification(DbUtil.Db, statementType ?? "all");
 
             if (showCheckNo || showNotes)
             {

--- a/CmsWeb/Areas/Manage/Controllers/AccountController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/AccountController.cs
@@ -182,6 +182,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         [HttpPost, MyRequireHttps]
         public ActionResult LogOn(AccountInfo m)
         {
+            var db = DbUtil.Db;
             Session.Remove("IsNonFinanceImpersonator");
             TryLoadAlternateShell();
             if (m.ReturnUrl.HasValue())
@@ -205,22 +206,22 @@ namespace CmsWeb.Areas.Manage.Controllers
             if (user.MustChangePassword)
                 return Redirect("/Account/ChangePassword");
 
-            var access = DbUtil.Db.Setting("LimitAccess", "");
+            var access = db.Setting("LimitAccess", "");
             if (access.HasValue())
                 if (!user.InRole("Developer"))
                     return Message(access);
 
-            var newleadertag = DbUtil.Db.FetchTag("NewOrgLeadersOnly", user.PeopleId, DbUtil.TagTypeId_System);
+            var newleadertag = db.FetchTag("NewOrgLeadersOnly", user.PeopleId, DbUtil.TagTypeId_System);
             if (newleadertag != null)
             {
                 if(!user.InRole("Access")) // if they already have Access role, then don't limit them with OrgLeadersOnly
-                    user.AddRoles(DbUtil.Db, "Access,OrgLeadersOnly".Split(','));
-                DbUtil.Db.Tags.DeleteOnSubmit(newleadertag);
-                DbUtil.Db.SubmitChanges();
+                    user.AddRoles(db, "Access,OrgLeadersOnly".Split(','));
+                db.Tags.DeleteOnSubmit(newleadertag);
+                db.SubmitChanges();
             }
 
             if (!m.ReturnUrl.HasValue())
-                if (!CMSRoleProvider.provider.IsUserInRole(user.Username, "Access"))
+                if (!CMSRoleProvider.provider.IsUserInRole(user.Username, "Access", db))
                     return Redirect("/Person2/" + Util.UserPeopleId);
             if (m.ReturnUrl.HasValue() && Url.IsLocalUrl(m.ReturnUrl))
                 return Redirect(m.ReturnUrl);

--- a/CmsWeb/Areas/Manage/Models/AccountModel.cs
+++ b/CmsWeb/Areas/Manage/Models/AccountModel.cs
@@ -106,11 +106,12 @@ namespace CmsWeb.Models
 
             if (checkOrgLeadersOnly && !Util2.OrgLeadersOnlyChecked)
             {
+                var db = DbUtil.Db;
                 DbUtil.LogActivity("iphone leadersonly check " + user.Username);
-                if (!Util2.OrgLeadersOnly && roleProvider.IsUserInRole(user.Username, "OrgLeadersOnly"))
+                if (!Util2.OrgLeadersOnly && roleProvider.IsUserInRole(user.Username, "OrgLeadersOnly", db))
                 {
                     Util2.OrgLeadersOnly = true;
-                    DbUtil.Db.SetOrgLeadersOnly();
+                    db.SetOrgLeadersOnly();
                     DbUtil.LogActivity("SetOrgLeadersOnly");
                 }
                 Util2.OrgLeadersOnlyChecked = true;
@@ -144,11 +145,12 @@ namespace CmsWeb.Models
 
             if (checkOrgLeadersOnly && !Util2.OrgLeadersOnlyChecked)
             {
+                var db = DbUtil.Db;
                 DbUtil.LogActivity("iphone leadersonly check " + user.Username);
-                if (!Util2.OrgLeadersOnly && roleProvider.IsUserInRole(user.Username, "OrgLeadersOnly"))
+                if (!Util2.OrgLeadersOnly && roleProvider.IsUserInRole(user.Username, "OrgLeadersOnly", db))
                 {
                     Util2.OrgLeadersOnly = true;
-                    DbUtil.Db.SetOrgLeadersOnly();
+                    db.SetOrgLeadersOnly();
                     DbUtil.LogActivity("SetOrgLeadersOnly");
                 }
                 Util2.OrgLeadersOnlyChecked = true;
@@ -249,7 +251,8 @@ namespace CmsWeb.Models
 
         public static UserValidationResult AuthenticateLogon(string userName, string password, string url)
         {
-            var userQuery = DbUtil.Db.Users.Where(uu =>
+            var db = DbUtil.Db;
+            var userQuery = db.Users.Where(uu =>
                 uu.Username == userName ||
                 uu.Person.EmailAddress == userName ||
                 uu.Person.EmailAddress2 == userName
@@ -288,12 +291,12 @@ namespace CmsWeb.Models
                         u.MustChangePassword = true;
                     }
                     u.IsLockedOut = false;
-                    DbUtil.Db.SubmitChanges();
+                    db.SubmitChanges();
                     user = u;
                     break;
                 }
 
-                if (password == DbUtil.Db.Setting("ImpersonatePassword", Guid.NewGuid().ToString()))
+                if (password == db.Setting("ImpersonatePassword", Guid.NewGuid().ToString()))
                 {
                     user = u;
                     impersonating = true;
@@ -303,7 +306,7 @@ namespace CmsWeb.Models
 
                 if (Membership.Provider.ValidateUser(u.Username, password))
                 {
-                    DbUtil.Db.Refresh(RefreshMode.OverwriteCurrentValues, u);
+                    db.Refresh(RefreshMode.OverwriteCurrentValues, u);
                     user = u;
                     break;
                 }

--- a/CmsWeb/Areas/OnlineReg/Controllers/Payment.cs
+++ b/CmsWeb/Areas/OnlineReg/Controllers/Payment.cs
@@ -194,7 +194,6 @@ namespace CmsWeb.Areas.OnlineReg.Controllers
             return View("Payment/Process", pf);
         }
 
-        [HttpPost]
         public ActionResult ConfirmDuePaid(int? id, string transactionId, decimal amount)
         {
             Response.NoCache();

--- a/CmsWeb/Areas/People/Views/Person/Giving/CustomStatments.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Giving/CustomStatments.cshtml
@@ -1,5 +1,7 @@
 ﻿@model CmsWeb.Areas.People.Models.ContributionsModel
 @using CmsWeb.Areas.Finance.Models.Report
+@using CmsData
+
 <div class="modal fade" id="customstatements-modal">
     <div class="modal-dialog modal-sm">
         <div class="modal-content">
@@ -11,7 +13,7 @@
                 <input type="hidden" id="" />
                 <div>
                     <ul>
-                        @foreach (var cs in ContributionStatements.CustomStatementsList())
+                        @foreach (var cs in ContributionStatements.CustomStatementsList(DbUtil.Db))
                         {
                             <li><a href="url?custom=@cs" data-customstatement="@cs">@cs</a></li>
                         }

--- a/CmsWeb/Areas/People/Views/Person/Giving/Statements.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Giving/Statements.cshtml
@@ -1,4 +1,5 @@
 ﻿@model ContributionsModel
+@using CmsData
 @using CmsWeb.Areas.Finance.Models.Report
 @using CmsWeb.Areas.People.Models
 @using UtilityExtensions
@@ -11,7 +12,7 @@
         source = "/Person2/InlineCodes/"
     };
     var finance = User.IsInRole("Finance") && ((string)Session["testnofinance"]) != "true";
-    string statements = null; ContributionStatements.CustomStatementsList();
+    string statements = null; ContributionStatements.CustomStatementsList(DbUtil.Db);
 }
 <form class="ajax" method="post" data-init="Editable" data-init2="ExtraEditable">
     <h4>Statements</h4>


### PR DESCRIPTION
Fix for https://trello.com/c/TPLknRYo/5140-statements-stuck-running-and-not-generating-statements-under-administration-contributions-statements-for-all-databases

This PR attempts to correct any use, intentional or otherwise of the helper method `DbUtil.Db` so that if it is used outside of an `HttpContext` thread it will have access to a database that was created using `DbUtil.Create(host)`  This whole class really needs to be destroyed but that would impact thousands of lines of code.  Baby steps...