### PR TITLE
Add support to filter Special Content files by keyword

### DIFF
--- a/CmsData/Extensions/Content.cs
+++ b/CmsData/Extensions/Content.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using UtilityExtensions;
+using System.Linq;
 
 namespace CmsData
 {
@@ -9,6 +11,26 @@ namespace CmsData
         public void RemoveGrammarly()
         {
             Body = Body.RemoveGrammarly();
+        }
+        public void SetKeyWords(CMSDataContext db, string[] keywords)
+        {
+            if (keywords == null || keywords.Length == 0)
+            {
+                db.ContentKeyWords.DeleteAllOnSubmit(ContentKeyWords);
+                db.SubmitChanges();
+                return;
+            }
+            var deletes = (from kw in ContentKeyWords
+                           where !keywords.Contains(kw.Word)
+                           select kw).ToList();
+            db.ContentKeyWords.DeleteAllOnSubmit(deletes);
+            var addlist = (from s in keywords
+                     join r in ContentKeyWords on s equals r.Word into g
+                     from t in g.DefaultIfEmpty()
+                     where t == null
+                     select s).ToList();
+            foreach (var s in addlist)
+                ContentKeyWords.Add(new ContentKeyWord {Id = Id, Word = s});
         }
     }
 }

--- a/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
@@ -185,8 +185,8 @@ namespace CmsWeb.Areas.Manage.Controllers
         public ActionResult ContentDelete(int id)
         {
             var content = DbUtil.ContentFromID(id);
-            DbUtil.Db.Contents.DeleteOnSubmit(content);
-            DbUtil.Db.SubmitChanges();
+            DbUtil.Db.ExecuteCommand("DELETE FROM dbo.ContentKeywords WHERE Id = {0}", id);
+            DbUtil.Db.ExecuteCommand("DELETE FROM dbo.Content WHERE Id = {0}", id);
             var url = GetIndexTabUrl(content);
             return Redirect(url);
         }

--- a/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
@@ -97,13 +97,13 @@ namespace CmsWeb.Areas.Manage.Controllers
             content.Title = newName;
             content.Body = "";
             content.DateCreated = DateTime.Now;
-            var ContentKeywordFitler = Session["ContentKeywordFilter"] as string;
-            if(ContentKeywordFitler.HasValue())
-                content.SetKeyWords(DbUtil.Db, new []{ContentKeywordFitler});
+            var ContentKeywordFilter = Session["ContentKeywordFilter"] as string;
+            if(ContentKeywordFilter.HasValue())
+                content.SetKeyWords(DbUtil.Db, new []{ContentKeywordFilter});
 
             DbUtil.Db.Contents.InsertOnSubmit(content);
             DbUtil.Db.SubmitChanges();
-            ViewBag.ContentKeywords = ContentKeywordFitler ?? "";
+            ViewBag.ContentKeywords = ContentKeywordFilter ?? "";
 
             return RedirectEdit(content);
         }

--- a/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
@@ -5,6 +5,7 @@
  * You may obtain a copy of the License at http://bvcms.codeplex.com/license
  */
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Text;
@@ -24,6 +25,7 @@ using System.Linq;
 using System.Web;
 using System.Web.UI.WebControls;
 using CmsWeb.Code;
+using Dapper;
 using Elmah;
 using Content = CmsData.Content;
 using Encoder = System.Drawing.Imaging.Encoder;
@@ -43,21 +45,36 @@ namespace CmsWeb.Areas.Manage.Controllers
             return View(new ContentModel());
         }
 
+        [HttpPost]
+        public ActionResult SetContentKeywordFilter(string keywordfilter, string tab)
+        {
+            if(keywordfilter.HasValue())
+                Session["ContentKeywordFilter"] = keywordfilter.trim();
+            else
+                Session.Remove("ContentKeywordFilter");
+            return Redirect($"/Display#tab_{tab}");
+        }
+
+
         public ActionResult ContentEdit(int? id, bool? snippet)
         {
             if (!id.HasValue)
                 throw new HttpException(404, "No ID found.");
 
-            var content = DbUtil.ContentFromID(id.Value);
-            if (content == null)
+            var q = from c in DbUtil.Db.Contents
+                    where c.Id == id.Value
+                    select new {content = c, keywords = string.Join(",", c.ContentKeyWords.Select(vv => vv.Word))};
+            var i = q.SingleOrDefault();
+            if(i == null)
                 throw new HttpException(404, "No ID found.");
 
             if (snippet == true)
             {
-                content.Snippet = true;
+                i.content.Snippet = true;
                 DbUtil.Db.SubmitChanges();
             }
-            return RedirectEdit(content);
+            ViewBag.ContentKeywords = i.keywords;
+            return RedirectEdit(i.content);
         }
         public ActionResult Content(int? id)
         {
@@ -80,15 +97,19 @@ namespace CmsWeb.Areas.Manage.Controllers
             content.Title = newName;
             content.Body = "";
             content.DateCreated = DateTime.Now;
+            var ContentKeywordFitler = Session["ContentKeywordFilter"] as string;
+            if(ContentKeywordFitler.HasValue())
+                content.SetKeyWords(DbUtil.Db, new []{ContentKeywordFitler});
 
             DbUtil.Db.Contents.InsertOnSubmit(content);
             DbUtil.Db.SubmitChanges();
+            ViewBag.ContentKeywords = ContentKeywordFitler ?? "";
 
             return RedirectEdit(content);
         }
 
         [HttpPost]
-        public ActionResult ContentUpdate(int id, string name, string title, string body, bool? snippet, int? roleid, string stayaftersave = null)
+        public ActionResult ContentUpdate(int id, string name, string title, string body, bool? snippet, int? roleid, string contentKeyWords, string stayaftersave = null)
         {
             var content = DbUtil.ContentFromID(id);
             content.Name = name;
@@ -97,6 +118,7 @@ namespace CmsWeb.Areas.Manage.Controllers
             content.RemoveGrammarly();
             content.RoleID = roleid ?? 0;
             content.Snippet = snippet;
+            content.SetKeyWords(DbUtil.Db, contentKeyWords.SplitStr(",").Select(vv => vv.trim()).ToArray());
 
             if (content.TypeID == ContentTypeCode.TypeEmailTemplate)
             {
@@ -224,7 +246,7 @@ namespace CmsWeb.Areas.Manage.Controllers
         //            return new GridResult(rd);
         //        }
         [HttpPost]
-        public ActionResult SavePythonScript(string name, string body)
+        public ActionResult SavePythonScript(string name, string body, string contentKeyWords)
         {
             var content = DbUtil.Db.Content(name, "", ContentTypeCode.TypePythonScript);
             content.Body = body;

--- a/CmsWeb/Areas/Manage/Models/ContentModel.cs
+++ b/CmsWeb/Areas/Manage/Models/ContentModel.cs
@@ -2,80 +2,102 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using System.Web.Mvc;
 using CmsData;
 using CmsData.Codes;
-using CmsWeb.Areas.Manage.Controllers;
 using UtilityExtensions;
 
 namespace CmsWeb.Models
 {
-	public class ContentModel
-	{
-		public IQueryable<Content> fetchHTMLFiles()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypeHtml
-					 orderby c.Name
-					 select c;
-		}
+    public class ContentModel
+    {
+        private string filter;
+        public string Filter => filter ?? (filter = HttpContext.Current.Session["ContentKeywordFilter"] as string ?? "");
 
-		public IQueryable<Content> fetchTextFiles()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypeText
-					 orderby c.Name
-					 select c;
-		}
-		public IQueryable<Content> fetchSqlScriptFiles()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypeSqlScript
-					 orderby c.Name
-					 select c;
-		}
-		public IQueryable<Content> fetchPythonScriptFiles()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypePythonScript
-					 orderby c.Name
-					 select c;
-		}
+        public IQueryable<Content> fetchHTMLFiles()
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypeHtml
+                   where !Filter.HasValue() || c.ContentKeyWords.Any(vv => vv.Word == Filter)
+                   orderby c.Name
+                   select c;
+        }
 
-		public IQueryable<Content> fetchEmailTemplates()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypeEmailTemplate
-					 orderby c.Name
-					 select c;
-		}
+        public IQueryable<Content> fetchTextFiles()
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypeText
+                   where !Filter.HasValue() || c.ContentKeyWords.Any(vv => vv.Word == Filter)
+                   orderby c.Name
+                   select c;
+        }
+        public IQueryable<Content> fetchSqlScriptFiles()
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypeSqlScript
+                   where !Filter.HasValue() || c.ContentKeyWords.Any(vv => vv.Word == Filter)
+                   orderby c.Name
+                   select c;
+        }
+        public IQueryable<Content> fetchPythonScriptFiles()
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypePythonScript
+                   where !Filter.HasValue() || c.ContentKeyWords.Any(vv => vv.Word == Filter)
+                   orderby c.Name
+                   select c;
+        }
+
+        public IQueryable<Content> fetchEmailTemplates()
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypeEmailTemplate
+                   orderby c.Name
+                   select c;
+        }
 
         public IQueryable<SavedDraft> fetchSavedDrafts()
-		{
-			return from c in DbUtil.Db.Contents
-					 where c.TypeID == ContentTypeCode.TypeSavedDraft
-                     from p in DbUtil.Db.Users.Where( p => p.UserId == c.OwnerID ).DefaultIfEmpty()
-                     from r in DbUtil.Db.Roles.Where( r => r.RoleId == c.RoleID ).DefaultIfEmpty()
-					 orderby c.Name
-					 select new SavedDraft()
-                     {
-                         created = c.DateCreated,
-                         id = c.Id,
-                         name = c.Name,
-                         owner = p.Username,
-                         role = r.RoleName,
-                         roleID = c.RoleID
-                     };
-		}
+        {
+            return from c in DbUtil.Db.Contents
+                   where c.TypeID == ContentTypeCode.TypeSavedDraft
+                   from p in DbUtil.Db.Users.Where(p => p.UserId == c.OwnerID).DefaultIfEmpty()
+                   from r in DbUtil.Db.Roles.Where(r => r.RoleId == c.RoleID).DefaultIfEmpty()
+                   orderby c.Name
+                   select new SavedDraft()
+                   {
+                       created = c.DateCreated,
+                       id = c.Id,
+                       name = c.Name,
+                       owner = p.Username,
+                       role = r.RoleName,
+                       roleID = c.RoleID
+                   };
+        }
 
-		public static List<Role> fetchRoles()
-		{
-			var r = from e in DbUtil.Db.Roles
-					  select e;
+        public static List<Role> fetchRoles()
+        {
+            var r = from e in DbUtil.Db.Roles
+                    select e;
 
-			var l = r.ToList();
-			l.Insert( 0, new Role() { RoleId = 0, RoleName = "Everyone" } );
-			return l;
-		}
+            var l = r.ToList();
+            l.Insert(0, new Role() { RoleId = 0, RoleName = "Everyone" });
+            return l;
+        }
+
+        private List<SelectListItem> keywords;
+        public List<SelectListItem> KeywordFilters()
+        {
+            if (keywords != null)
+                return keywords;
+            var list = (from kw in DbUtil.Db.ContentKeyWords
+                        orderby kw.Word
+                        select kw.Word).Distinct().ToList();
+            var keywordfilter = HttpContext.Current.Session["ContentKeywordFilter"] as string;
+            keywords = list.Select(vv => new SelectListItem() { Text = vv, Value = vv, Selected = vv == keywordfilter }).ToList();
+            keywords.Insert(0, new SelectListItem() { Text = "(not specified)", Value = "" });
+            return keywords;
+        }
+
 
         public class SavedDraft
         {
@@ -92,5 +114,5 @@ namespace CmsWeb.Models
             public bool Shared => !Owner && shared;
             public bool Other => !Shared && roleID != 0;
         }
-	}
+    }
 }

--- a/CmsWeb/Areas/Manage/Views/Display/EditDraft.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditDraft.cshtml
@@ -34,7 +34,7 @@
             <div class="form-group">
               @Html.TextArea("body", new { @class = "form-control", rows = "26" })
             </div>
-            <a href="/Display/#tab_savedDrafts" class="btn btn-default">Cancel</a>
+            <a href="/Display/#tab_savedDrafts" class="btn btn-default">Back to List</a>
             <a href="#" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
             <input type="submit" class="btn btn-primary" value="Save Draft" />
           </div>

--- a/CmsWeb/Areas/Manage/Views/Display/EditHTML.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditHTML.cshtml
@@ -19,6 +19,12 @@
                 @Html.TextBox("title", Model.Title, new { @class = "form-control" })
               </div>
             </div>
+            <div class="col-sm-4">
+              <div class="form-group">
+                <label for="ContentKeyWords" class="control-label">Content KeyWords</label>
+                @Html.TextBox("ContentKeyWords", ViewBag.ContentKeyWords as string, new { @class = "form-control" })
+              </div>
+            </div>
           </div>
           <div class="form-group">
             <div class="checkbox">
@@ -30,7 +36,7 @@
           <div class="form-group">
             @Html.TextArea("body", new { @class = "form-control", rows = "26" })
           </div>
-          <a href="/Display/#tab_htmlContent" class="btn btn-default">Cancel</a>
+          <a href="/Display/#tab_htmlContent" class="btn btn-default">Back to List</a>
           <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
           <input type="submit" class="btn btn-primary" value="Save Content"/>
         </div>

--- a/CmsWeb/Areas/Manage/Views/Display/EditHTML.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditHTML.cshtml
@@ -48,16 +48,47 @@
 }
 @section scripts
 {
-  @ViewExtensions2.CkEditor()
-  @Fingerprint.Script("/Content/touchpoint/js/admin/EditHtml.js")
-  <script type="text/javascript">
+    @ViewExtensions2.CkEditor()
+    @Fingerprint.Script("/Content/touchpoint/js/admin/EditHtml.js")
+    <script type="text/javascript">
 
-    function getParameterByName(name) {
-      name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-      var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-          results = regex.exec(location.search);
-      return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
-    }
+        function getParameterByName(name) {
+            name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+            var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+                results = regex.exec(location.search);
+            return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        }
 
-  </script>
+        $(function() {
+            $("a.delete").click(function(ev) {
+                ev.preventDefault();
+                swal({
+                        title: "Are you sure?",
+                        type: "warning",
+                        showCancelButton: true,
+                        confirmButtonClass: "btn-danger",
+                        confirmButtonText: "Yes, delete it!",
+                        closeOnConfirm: false
+                    },
+                    function() {
+                        $.post("/Display/ContentDelete",
+                            { id: "@Model.Id" },
+                            function(ret) {
+                                if (ret && ret.error)
+                                    swal("Error!", ret.error, "error");
+                                else {
+                                    swal({
+                                            title: "Deleted!",
+                                            type: "success"
+                                        },
+                                        function() {
+                                            window.location = "/Manage/Display/#tab_textContent";
+                                        });
+                                }
+                            });
+                    });
+            });
+        });
+
+    </script>
 }

--- a/CmsWeb/Areas/Manage/Views/Display/EditPythonScript.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditPythonScript.cshtml
@@ -18,6 +18,12 @@
                   @Html.TextBox("name", Model.Name, new { @class = "form-control" })
                 </div>
               </div>
+            <div class="col-sm-4">
+              <div class="form-group">
+                <label for="ContentKeyWords" class="control-label">Content KeyWords</label>
+                @Html.TextBox("ContentKeyWords", ViewBag.ContentKeyWords as string, new { @class = "form-control" })
+              </div>
+            </div>
             </div>
           <div class="form-group">
             <nav class="navbar navbar-inverse" style="margin-bottom: 0;">
@@ -39,7 +45,8 @@
             }
             @Html.HiddenFor(m => m.Body)
           </div>
-          <a href="/Manage/Display/#tab_pythonScripts" class="btn btn-default">Cancel</a> <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
+            <a href="/Manage/Display/#tab_pythonScripts" class="btn btn-default">Back to List</a>
+            <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
           @if (User.IsInRole("Admin"))
           {
             <a href="#" class="btn btn-primary save">Save Python Script</a>

--- a/CmsWeb/Areas/Manage/Views/Display/EditSqlScript.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditSqlScript.cshtml
@@ -17,6 +17,12 @@
                   @Html.TextBox("name", Model.Name, new { @class = "form-control" })
                 </div>
               </div>
+            <div class="col-sm-4">
+              <div class="form-group">
+                <label for="ContentKeyWords" class="control-label">Content KeyWords</label>
+                @Html.TextBox("ContentKeyWords", ViewBag.ContentKeyWords as string, new { @class = "form-control" })
+              </div>
+            </div>
             </div>
             <div class="form-group">
               <nav class="navbar navbar-inverse" style="margin-bottom: 0;">
@@ -40,7 +46,8 @@
               <textarea id="mobile-body" name="mobile-body" class="form-control" rows="15" style="display:none; font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">@Model.Body</textarea>
               @Html.HiddenFor(m => m.Body)
             </div>
-            <a href="/Manage/Display/#tab_sqlScripts" class="btn btn-default">Cancel</a> <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
+              <a href="/Manage/Display/#tab_sqlScripts" class="btn btn-default">Back to List</a>
+              <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
             @if (User.IsInRole("Admin"))
             {
                 <a href="#" class="btn btn-primary save">Save Sql Script</a>

--- a/CmsWeb/Areas/Manage/Views/Display/EditTemplate.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditTemplate.cshtml
@@ -34,7 +34,7 @@
             <div class="form-group">
               @Html.TextArea("body", new { @class = "form-control", rows = "26" })
             </div>
-            <a href="/Display/#tab_emailTemplates" class="btn btn-default">Cancel</a>
+            <a href="/Display/#tab_emailTemplates" class="btn btn-default">Back to List</a>
             <a href="#" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
             <input type="submit" class="btn btn-primary" value="Save Template" />
           </div>

--- a/CmsWeb/Areas/Manage/Views/Display/EditText.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditText.cshtml
@@ -10,14 +10,20 @@
         <div class="col-md-9">
             <div class="box box-responsive">
                 <div class="box-content">
-            <div class="row">
-              <div class="col-sm-4">
-                <div class="form-group">
-                  <label for="name" class="control-label">Name</label>
-                  @Html.TextBox("name", Model.Name, new { @class = "form-control" })
-                </div>
-              </div>
-            </div>
+                    <div class="row">
+                        <div class="col-sm-4">
+                            <div class="form-group">
+                                <label for="name" class="control-label">Name</label>
+                                @Html.TextBox("name", Model.Name, new { @class = "form-control" })
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="form-group">
+                                <label for="ContentKeyWords" class="control-label">Content KeyWords</label>
+                                @Html.TextBox("ContentKeyWords", ViewBag.ContentKeyWords as string, new { @class = "form-control" })
+                            </div>
+                        </div>
+                    </div>
                     <div class="form-group">
                         <nav class="navbar navbar-inverse hidden-xs" style="margin-bottom: 0;">
                             <div class="container-fluid">
@@ -49,7 +55,9 @@
                         <textarea id="mobile-body" name="mobile-body" class="form-control" rows="15" style="display:none; font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">@Model.Body</textarea>
                         @Html.HiddenFor(m => m.Body)
                     </div>
-                    <a href="/Display/#tab_textContent" class="btn btn-default">Cancel</a> <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a> <a href="#" class="btn btn-primary save">Save Content</a>
+                    <a href="/Display/#tab_textContent" class="btn btn-default">Back to List</a>
+                    <a href="/Display/ContentDelete/@Model.Id" class="btn btn-danger delete"><i class="fa fa-trash"></i> Delete</a>
+                    <a href="#" class="btn btn-primary save">Save Content</a>
                 </div>
             </div>
         </div>
@@ -80,7 +88,7 @@
                 $(ele).prop("checked", true);
                 $(ele).closest('label').addClass('active');
             }
-            
+
             $("input[name='editor-mode']").change(function () {
                 var mode = $(this).val();
                 editor.getSession().setMode("ace/mode/" + mode);

--- a/CmsWeb/Areas/Manage/Views/Display/Index.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/Index.cshtml
@@ -1,10 +1,12 @@
 ﻿@using CmsWeb.Models
 @using UtilityExtensions
 @model ContentModel
+
 @{
     Layout = ViewExtensions2.TouchPointLayout();
     ViewBag.Title = "Special Content";
     ViewBag.PageHeader = "Special Content";
+    var ContentKeywordFilter = Session["ContentKeywordFilter"] as string;
 
     var roleList = ContentModel.fetchRoles();
 }
@@ -16,19 +18,18 @@
         <ul class="nav nav-tabs" id="special-content-tabs">
             <li class="active"><a href="#htmlContent" aria-controls="htmlContent" data-toggle="tab"><i class="fa fa-file-code-o"></i>&nbsp;&nbsp;Html Content</a></li>
             <li><a href="#textContent" aria-controls="textContent" data-toggle="tab"><i class="fa fa-file-text"></i>&nbsp;&nbsp;Text Content</a></li>
+            @if (!ContentKeywordFilter.HasValue())
+            {
             <li><a href="#emailTemplates" aria-controls="emailTemplates" data-toggle="tab"><i class="fa fa-envelope"></i>&nbsp;&nbsp;Email Templates</a></li>
             <li><a href="#savedDrafts" aria-controls="savedDrafts" data-toggle="tab"><i class="fa fa-clipboard"></i>&nbsp;&nbsp;Saved Drafts</a></li>
+            }
             <li><a href="#sqlScripts" aria-controls="sqlScripts" data-toggle="tab"><i class="fa fa-database"></i>&nbsp;&nbsp;Sql Scripts</a></li>
             <li><a href="#pythonScripts" aria-controls="pythonScripts" data-toggle="tab"><i class="fa fa-code"></i>&nbsp;&nbsp;Python Scripts</a></li>
         </ul>
         <div class="tab-content">
             <div class="tab-pane fade in active" id="htmlContent">
                 <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <a href="#" newtype="0" newmessage="Create New Html File" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Html File</a>
-                        </div>
-                    </div>
+                    @SetHeaderRow("htmlContent")
                 </div>
                 <div class="row">
                     <div class="col-sm-12">
@@ -52,17 +53,15 @@
                                 </tbody>
                             </table>
                         </div>
-                        <a href="#" newtype="0" newmessage="Create New Html File" class="btn btn-success btn-block visible-xs-block"><i class="fa fa-plus-circle"></i> New Html File</a>
                     </div>
+                </div>
+                <div class="row visible-xs">
+                    @SetHeaderRow("htmlContent")
                 </div>
             </div>
             <div class="tab-pane fade" id="textContent">
                 <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <a href="#" newtype="1" newmessage="Create New Text File" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Text File</a>
-                        </div>
-                    </div>
+                    @SetHeaderRow("textContent")
                 </div>
                 <div class="row">
                     <div class="col-sm-12">
@@ -86,134 +85,133 @@
                                 </tbody>
                             </table>
                         </div>
-                        <a href="#" newtype="1" newmessage="Create New Text File" class="btn btn-success visible-xs-block btn-block"><i class="fa fa-plus-circle"></i> New Text File</a>
                     </div>
+                </div>
+                <div class="row visible-xs">
+                    @SetHeaderRow("textContent")
                 </div>
             </div>
-            <div class="tab-pane fade" id="emailTemplates">
-                <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <a href="#" newtypewithrole="2" newmessage="Create New Email Template" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Email Template</a>
+            @if (!ContentKeywordFilter.HasValue())
+            {
+                <div class="tab-pane fade" id="emailTemplates">
+                    <div class="row hidden-xs">
+                        <div class="col-sm-12">
+                            <div class="pull-right">
+                                <a href="#" newtypewithrole="2" newmessage="Create New Email Template" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Email Template</a>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <br />
-                <div class="row">
-                    <div class="col-sm-12">
-                        <div class="row">
-                            @foreach (var t in Model.fetchEmailTemplates())
-                            {
-                                var ro = roleList.FirstOrDefault(r => r.RoleId == t.RoleID);
-                                <div class="col-sm-6 col-md-4 col-lg-3" style="margin-top: 5px; margin-bottom: 5px;">
-                                    <div class="row">
-                                        <div class="col-xs-4">
-                                            <a href="/Display/ContentEdit/@t.Id">
-                                                <img src="/Image/@t.ThumbID" class="img-responsive img-thumbnail" />
-                                            </a>
-                                        </div>
-                                        <div class="col-xs-8">
-                                            <a href="/Display/ContentEdit/@t.Id"><strong>@t.Name</strong></a><br />
-                                            Limited to Role: @(ro != null ? ro.RoleName : "missing role!")
-                                        </div>
-                                    </div>
-                                </div>
-                            }
-                            <a href="#" newtypewithrole="2" newmessage="Create New Email Template" class="btn btn-success visible-xs-block btn-block"><i class="fa fa-plus-circle"></i> New Email Template</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="tab-pane fade" id="savedDrafts">
-                <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <button type="button" class="btn btn-danger draftDelete"><i class="fa fa-trash"></i> Delete Selected</button>
-                        </div>
-                    </div>
-                </div>
-                <form id="savedDraftsForm" action="/Display/ContentDeleteDrafts">
+                    <br/>
                     <div class="row">
                         <div class="col-sm-12">
-                            <div class="table-responsive">
-                                <table class="table table-striped">
-                                    <thead>
+                            <div class="row">
+                                @foreach (var t in Model.fetchEmailTemplates())
+                                {
+                                    var ro = roleList.FirstOrDefault(r => r.RoleId == t.RoleID);
+                                    <div class="col-sm-6 col-md-4 col-lg-3" style="margin-top: 5px; margin-bottom: 5px;">
+                                        <div class="row">
+                                            <div class="col-xs-4">
+                                                <a href="/Display/ContentEdit/@t.Id">
+                                                    <img src="/Image/@t.ThumbID" class="img-responsive img-thumbnail"/>
+                                                </a>
+                                            </div>
+                                            <div class="col-xs-8">
+                                                <a href="/Display/ContentEdit/@t.Id"><strong>@t.Name</strong></a><br/>
+                                                Limited to Role: @(ro != null ? ro.RoleName : "missing role!")
+                                            </div>
+                                        </div>
+                                    </div>
+                                }
+                                <a href="#" newtypewithrole="2" newmessage="Create New Email Template" class="btn btn-success visible-xs-block btn-block"><i class="fa fa-plus-circle"></i> New Email Template</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="savedDrafts">
+                    <div class="row hidden-xs">
+                        <div class="col-sm-12">
+                            <div class="pull-right">
+                                <button type="button" class="btn btn-danger draftDelete"><i class="fa fa-trash"></i> Delete Selected</button>
+                            </div>
+                        </div>
+                    </div>
+                    <form id="savedDraftsForm" action="/Display/ContentDeleteDrafts">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <div class="table-responsive">
+                                    <table class="table table-striped">
+                                        <thead>
                                         <tr>
-                                            <th style="width: 5px;"><input type="checkbox" id="draftAll" value="all" /></th>
+                                            <th style="width: 5px;"><input type="checkbox" id="draftAll" value="all"/></th>
                                             <th>Name</th>
                                             <th>Owner</th>
                                             <th>Role</th>
                                             <th>Created Date</th>
                                         </tr>
-                                    </thead>
-                                    @foreach (var item in Model.fetchSavedDrafts())
-                                    {
-                                        <tr>
-                                            <td style="width: 5px;">
-                                                <input draft="yes" type="checkbox" name="draftID" value="@item.id" />
-                                            </td>
-                                            <td>
-                                                @Helper.AnchorLink(item.name.HasValue() ? item.name : "notnamed", "/Display/ContentEdit/" + item.id)
-                                            </td>
-                                            <td>
-                                                @item.owner
-                                            </td>
-                                            <td>
-                                                @(item.roleID == 0 ? "Everyone" : item.role)
-                                            </td>
-                                            <td>
-                                                @item.created.FormatDate()
-                                            </td>
-                                        </tr>
-                                    }
-                                </table>
+                                        </thead>
+                                        @foreach (var item in Model.fetchSavedDrafts())
+                                        {
+                                            <tr>
+                                                <td style="width: 5px;">
+                                                    <input draft="yes" type="checkbox" name="draftID" value="@item.id"/>
+                                                </td>
+                                                <td>
+                                                    @Helper.AnchorLink(item.name.HasValue() ? item.name : "notnamed", "/Display/ContentEdit/" + item.id)
+                                                </td>
+                                                <td>
+                                                    @item.owner
+                                                </td>
+                                                <td>
+                                                    @(item.roleID == 0 ? "Everyone" : item.role)
+                                                </td>
+                                                <td>
+                                                    @item.created.FormatDate()
+                                                </td>
+                                            </tr>
+                                        }
+                                    </table>
+                                </div>
+                                <button type="button" class="btn btn-danger visible-xs-block btn-block draftDelete"><i class="fa fa-trash"></i> Delete Selected</button>
                             </div>
-                            <button type="button" class="btn btn-danger visible-xs-block btn-block draftDelete"><i class="fa fa-trash"></i> Delete Selected</button>
                         </div>
-                    </div>
-                </form>
-            </div>
+                    </form>
+                </div>
+            }
             <div class="tab-pane fade" id="sqlScripts">
                 <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <a href="#" newtype="4" newmessage="Create New Sql Script File" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Sql Script File</a>
-                        </div>
-                    </div>
+                        @SetHeaderRow("sqlScripts")
                 </div>
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="table-responsive">
                             <table class="table table-striped">
                                 <thead>
-                                    <tr>
-                                        <th>Name</th>
-                                    </tr>
+                                <tr>
+                                    <th>Name</th>
+                                </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach (var item in Model.fetchSqlScriptFiles())
+                                @foreach (var item in Model.fetchSqlScriptFiles())
+                                {
+                                    if (!string.IsNullOrWhiteSpace(item.Name))
                                     {
-                                        if (!string.IsNullOrWhiteSpace(item.Name))
-                                        {
-                                            <tr>
-                                                <td>@Helper.AnchorLink(item.Name, "/Display/ContentEdit/" + item.Id)</td>
-                                            </tr>
-                                        }
+                                        <tr>
+                                            <td>@Helper.AnchorLink(item.Name, "/Display/ContentEdit/" + item.Id)</td>
+                                        </tr>
                                     }
+                                }
                                 </tbody>
                             </table>
                         </div>
-                        <a href="#" newtype="4" newmessage="Create New Sql Script File" class="btn btn-success visible-xs-block btn-block"><i class="fa fa-plus-circle"></i> New Sql Script File</a>
                     </div>
+                </div>
+                <div class="row visible-xs">
+                    @SetHeaderRow("sqlScripts")
                 </div>
             </div>
             <div class="tab-pane fade" id="pythonScripts">
                 <div class="row hidden-xs">
-                    <div class="col-sm-12">
-                        <div class="pull-right">
-                            <a href="#" newtype="5" newmessage="Create New Python Script File" class="btn btn-success"><i class="fa fa-plus-circle"></i> New Python Script File</a>
-                        </div>
-                    </div>
+                    @SetHeaderRow("pythonScripts")
                 </div>
                 <div class="row">
                     <div class="col-sm-12">
@@ -237,8 +235,10 @@
                                 </tbody>
                             </table>
                         </div>
-                        <a href="#" newtype="5" newmessage="Create New Python Script File" class="btn btn-success visible-xs-block btn-block"><i class="fa fa-plus-circle"></i> New Python Script File</a>
                     </div>
+                </div>
+                <div class="row visible-xs">
+                    @SetHeaderRow("pythonScripts")
                 </div>
             </div>
         </div>
@@ -302,6 +302,44 @@
         </div>
     </div>
 </div>
+@helper SetHeaderRow(string tab)
+{
+    var text = "";
+    var type = 0;
+    switch (tab)
+    {
+        case "htmlContent":
+            text = "Html";
+            type = 0;
+            break;
+        case "textContent":
+            text = "Text";
+            type = 1;
+            break;
+        case "sqlScripts":
+            text = "SQL Script";
+            type = 4;
+            break;
+        case "pythonScripts":
+            text = "Python Script";
+            type = 5;
+            break;
+    }
+    var keywords = Model.KeywordFilters();
+    <div class="col-sm-12">
+        @if (keywords.Count > 1)
+        {
+        <form method="post" action="/Display/SetContentKeywordFilter" style="margin-right: 2em; display: inline">
+            @Html.Hidden("tab", tab)
+            Keyword Filter: @Html.DropDownList("keywordfilter", keywords)
+            <button type="submit">Set</button>
+        </form>
+        }
+        <div class="pull-right" style="display: inline-block">
+            <span class="pull-right"><a href="#" newtype="@type" newmessage="Create New @text File" class="btn btn-success"><i class="fa fa-plus-circle"></i> New @text File</a></span>
+        </div>
+    </div>
+}
 @section scripts
 {
     @Fingerprint.Script("/Content/touchpoint/lib/bootstrap-tabdrop/js/bootstrap-tabdrop.js")
@@ -382,10 +420,10 @@
                     confirmButtonText: "Yes, delete draft(s)!",
                     closeOnConfirm: true
                 },
-                function () {
-                    $.block();
-                    $("#savedDraftsForm").submit();
-                });
+                    function () {
+                        $.block();
+                        $("#savedDraftsForm").submit();
+                    });
             });
 
             $("#draftAll").change(function () {


### PR DESCRIPTION
Each file can have one or more keywords added to it via the ContentKeywords table. This table already exists but has never been used. A comma separated list of keywords can be assigned when editing the file. This only applies to HTML, Text, Sql Scripts and Python Scripts files. The Use Case is when you have multiple related files for a special project. Using this feature, you can filter out all the noise of other, unrelated files.

The filter is entered at the top of each list of files on the various tabs. The dropdown to select the keyword is only displayed if there available keywords on files. The filter is stored in a session variable and remains on until specifically removed by selecting the "(not specified)" item in the dropdown list.

When creating a new file while a keyword filter is set, that keyword is automatically assigned.