### PR TITLE
Austin fundmanager remove current custom reports

### DIFF
--- a/CmsWeb/Areas/Finance/Models/TotalsByFundModel.cs
+++ b/CmsWeb/Areas/Finance/Models/TotalsByFundModel.cs
@@ -1,17 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Web.Mvc;
 using CmsData;
 using CmsData.API;
 using CmsData.Codes;
 using CmsData.View;
 using CmsWeb.Code;
-using UtilityExtensions;
-using System.Text;
 using Dapper;
 using MoreLinq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.Mvc;
+using UtilityExtensions;
 
 namespace CmsWeb.Models
 {
@@ -37,7 +36,10 @@ namespace CmsWeb.Models
             var today = Util.Now.Date;
             var first = new DateTime(today.Year, today.Month, 1);
             if (today.Day < 8)
+            {
                 first = first.AddMonths(-1);
+            }
+
             Dt1 = first;
             Dt2 = first.AddMonths(1).AddDays(-1);
             Online = 2;
@@ -45,7 +47,7 @@ namespace CmsWeb.Models
 
         public FundTotalInfo FundTotal;
 
-        class ContributionIdItem
+        private class ContributionIdItem
         {
             public int ContributionId { get; set; }
         }
@@ -68,17 +70,27 @@ namespace CmsWeb.Models
             };
 
             var x = api.FetchContributions();
-            var list = x.Select(xx => new ContributionIdItem{ContributionId = xx.ContributionId}).ToList();
+            var list = x.Select(xx => new ContributionIdItem { ContributionId = xx.ContributionId }).ToList();
             var dt = ExcelExportModel.ToDataTable(list);
             dt.SaveAs("D:\\cids.xlsx");
         }
 
         public IEnumerable<string> CustomReports()
         {
+            // if a user is a member of the fundmanager role, we do not want to enable custom reports as this could bypass the fund restrictions at present
+            var fundmanagerRoleName = "FundManager";
+            var currentUserIsFundManager = DbUtil.Db.CurrentUser.Roles.Contains(fundmanagerRoleName, StringComparer.OrdinalIgnoreCase);
+
+            if (currentUserIsFundManager)
+            {
+                return new string[] { };
+            }
+
             var q = from c in DbUtil.Db.Contents
-                where c.TypeID == ContentTypeCode.TypeSqlScript
-                where c.Body.Contains("--class=TotalsByFund")
-                select c.Name;
+                    where c.TypeID == ContentTypeCode.TypeSqlScript
+                    where c.Body.Contains("--class=TotalsByFund")
+                    select c.Name;
+
             return q;
         }
 
@@ -110,13 +122,14 @@ namespace CmsWeb.Models
                foreach (var s in v)
                   tw.WriteLine(s);
 #endif
-            
+
 
             if (IncludeBundleType)
+            {
                 q = (from c in api.FetchContributions()
                      let BundleType = c.BundleDetails.First().BundleHeader.BundleHeaderType.Description
                      let BundleTypeId = c.BundleDetails.First().BundleHeader.BundleHeaderTypeId
-                     group c by new {c.FundId, BundleTypeId, BundleType}
+                     group c by new { c.FundId, BundleTypeId, BundleType }
                      into g
                      orderby g.Key.FundId, g.Key.BundleTypeId
                      select new FundTotalInfo
@@ -130,7 +143,9 @@ namespace CmsWeb.Models
                          Count = g.Count(),
                          model = this
                      }).ToList();
+            }
             else
+            {
                 q = (from c in api.FetchContributions()
                      group c by c.FundId into g
                      orderby g.Key
@@ -143,6 +158,7 @@ namespace CmsWeb.Models
                          Count = g.Count(),
                          model = this
                      }).ToList();
+            }
 
             FundTotal = new FundTotalInfo
             {
@@ -162,7 +178,7 @@ namespace CmsWeb.Models
 
             string fundIds = string.Empty;
 
-            if(customFundIds?.Count > 0)
+            if (customFundIds?.Count > 0)
             {
                 fundIds = authorizedFundIds.Where(f => customFundIds.Contains(f)).JoinInts(",");
             }
@@ -244,22 +260,44 @@ namespace CmsWeb.Models
             var sb = new StringBuilder(baseurl);
 
             if (fundid.HasValue)
+            {
                 Append(sb, "fundid=" + fundid);
+            }
+
             if (bundletypeid.HasValue)
+            {
                 Append(sb, "bundletype=" + bundletypeid);
+            }
 
             if (Dt1.HasValue)
+            {
                 Append(sb, "dt1=" + Dt1.ToSortableDate());
+            }
+
             if (Dt2.HasValue)
+            {
                 Append(sb, "dt2=" + Dt2.ToSortableDate());
+            }
+
             if (!IncUnclosedBundles)
+            {
                 Append(sb, "includeunclosedbundles=false");
+            }
+
             if (TaxDedNonTax != "TaxDed")
+            {
                 Append(sb, "taxnontax=" + TaxDedNonTax);
+            }
+
             if (CampusId > 0)
+            {
                 Append(sb, "campus=" + CampusId);
+            }
+
             if (Online < 2)
+            {
                 Append(sb, "online=" + Online);
+            }
 
             return sb.ToString();
         }
@@ -289,7 +327,10 @@ namespace CmsWeb.Models
                 p.Add("@ActiveTagFilter", tagid);
             }
             else
+            {
                 p.Add("@ActiveTagFilter");
+            }
+
             return p;
         }
     }

--- a/CmsWeb/Code/ModelViewModel.cs
+++ b/CmsWeb/Code/ModelViewModel.cs
@@ -95,13 +95,13 @@ namespace CmsWeb.Code
             var viewmodelProps = viewmodel.GetType().GetProperties().Where(pp => pp.CanWrite).ToArray();
             var changes = new List<ChangeDetail>();
             var only = onlyfields.Split(',');
-            var exclude = excludefields.Split(',');
+            var exclude = excludefields?.Split(',');
 
             foreach (var vm in viewmodelProps)
             {
                 if (onlyfields.HasValue() && !only.Contains(vm.Name))
                     continue;
-                if (excludefields.HasValue() && exclude.Contains(vm.Name))
+                if (exclude != null && exclude.Contains(vm.Name))
                     continue;
                 if (vm.HasAttribute<NoUpdate>())
                     continue;


### PR DESCRIPTION
**Reason**

This was brought up during testing of the fund manager code. We currently allow custom reports (sql statements) to be stored and executed and these do not honor the restrictions on funds. The decision, at present, is to not display these reports to users who are members of the FundManager role. This is the modifier role to indicate a user is only authorized for specific funds. 

**Trello**

https://trello.com/c/zyeqZmz6/5032-fund-based-finance-roles#comment-5bad1b9dc9a67b8b5ac85c04