### PR TITLE
Daniel save payment box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ CmsWeb/test.py
 ttt.json
 /IronPythonApplication1/test.py
 HTMLPage1.html
+/CmsWeb/package-lock.json

--- a/CmsWeb/Areas/OnlineReg/Views/OnlineReg/OnePageGiving/Index.cshtml
+++ b/CmsWeb/Areas/OnlineReg/Views/OnlineReg/OnePageGiving/Index.cshtml
@@ -268,7 +268,7 @@
                 <div class="form-actions text-right">
                     @if (Model.OnlineRegPersonModel.LoggedIn && !vaultDisabled)
                     {
-                        <span style="margin-right: 2em;">@Html.CheckBox("SavePayInfo", Model.PaymentForm.SavePayInfo) Save Payment Information</span>
+                        <span id="savePayArea" style="margin-right: 2em;">@Html.CheckBox("SavePayInfo", Model.PaymentForm.SavePayInfo) Save Payment Information</span>
                     }
                     <input type="submit" id="submitit" value="Make Gift" class="btn btn-primary btn-lg">
                     @if (processorerror.HasValue())

--- a/CmsWeb/Areas/OnlineReg/Views/OnlineReg/Payment/Process.cshtml
+++ b/CmsWeb/Areas/OnlineReg/Views/OnlineReg/Payment/Process.cshtml
@@ -102,9 +102,11 @@
       @if (Model.NoCreditCardsAllowed == false)
       {
           <div class="Card">
-            @Html.EditorFor(m => m.CreditCard, new { autocomplete = Model.AutocompleteOnOff, Label = debitcredit })
-            @Html.EditorFor(m => m.Expires, new { classes = "narrow" })
-            @Html.EditorFor(m => m.CVV, new { classes = "narrow", autocomplete = Model.AutocompleteOnOff })
+              @Html.EditorFor(m => m.CreditCard, new { autocomplete = Model.AutocompleteOnOff, Label = debitcredit })
+              @Html.EditorFor(m => m.Expires, new { classes = "narrow" })
+              @Html.EditorFor(m => m.CVV, new { classes = "narrow", autocomplete = Model.AutocompleteOnOff })
+              <input type="hidden" id="hdnCreditCardOnFile" data-value="@Model.CreditCard" />
+              <input type="hidden" id="hdnExpiresOnFile" data-value="@Model.Expires" />
           </div>
       }
       @if (Model.NoEChecksAllowed == false)

--- a/CmsWeb/Areas/OnlineReg/Views/OnlineReg/Payment/Process.cshtml
+++ b/CmsWeb/Areas/OnlineReg/Views/OnlineReg/Payment/Process.cshtml
@@ -120,7 +120,7 @@
         <div>
           @if (Model.IsLoggedIn == true && !VaultDisabled)
           {
-              <span style="margin-right: 2em;">@Html.CheckBoxFor(m => m.SavePayInfo) Save Payment Information</span>
+              <span id="savePayArea" style="margin-right: 2em;">@Html.CheckBoxFor(m => m.SavePayInfo) Save Payment Information</span>
           }
           @Helper.OnlineRegSubmitButton("Make Payment", onlyoneallowed: true, style: "btn-primary min-width15em")
         </div>

--- a/CmsWeb/Content/touchpoint/js/onlinereg/OnlineRegPayment2.js
+++ b/CmsWeb/Content/touchpoint/js/onlinereg/OnlineRegPayment2.js
@@ -138,11 +138,54 @@ $(function () {
     $.ShowPaymentInfo = function (v) {
         $(".Card").hide();
         $(".Bank").hide();
-        if (v === 'C')
+        if (v === 'C') {
             $(".Card").show();
+            if ($('#CreditCard').val().startsWith('X')) {
+                $("#savePayArea").hide();
+                $('#SavePayInfo').prop('checked', true);
+            }
+            else {
+                $('#savePayArea').show();
+                $('#SavePayInfo').prop('checked', false);
+            }
+            CancelCreditCardInfoUpdate();
+        }
         else if (v === 'B') {
             $(".Bank").show();
+            if ($('#Routing').val().startsWith('X') && $('#Account').val().startsWith('X')) {
+                $("#savePayArea").hide();
+                $('#SavePayInfo').prop('checked', true);
+            }
+            else {
+                showSavePayUncheckedBox();
+            }
             CancelCreditCardInfoUpdate();
+        }
+    };
+    $.ShowPaymentInfo2 = function (v) {
+        $(".Card").hide();
+        $(".Bank").hide();
+        if (v === 'C') {
+            $(".Card").show();
+            if ($('#CreditCard').val().startsWith('X')) {
+                $("#savePayArea").hide();
+                $('#SavePayInfo').prop('checked', true);
+            }
+            else {
+                $('#savePayArea').show();
+                $('#SavePayInfo').prop('checked', false);
+            }
+        }
+        else if (v === 'B') {
+            $(".Bank").show();
+            if ($('#Account').val().startsWith('X')) {
+                $("#savePayArea").hide();
+                $('#SavePayInfo').prop('checked', true);
+            }
+            else {
+                $('#savePayArea').show();
+                $('#SavePayInfo').prop('checked', false);
+            }
         }
     };
     $.SetRepeatPatternText = function(v) {
@@ -201,24 +244,41 @@ $(function () {
         $('#CreditCard').change(function () {
             $('#CVV').parents('.form-group').show();
             if ($('#CreditCard').val().startsWith('X')) {
-                $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));
-                $('#savePayArea').show();
-                $('#SavePayInfo').prop('checked', false);
+                $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));                
             }
-            $('#CancelUpdateText').parents('.form-group').show();
+            showSavePayUncheckedBox();
         });
         $('#Expires').change(function () {
             if ($('#CreditCard').val().startsWith('X')) {
-                $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));
-                $('#savePayArea').show();
-                $('#SavePayInfo').prop('checked',false);               
+                $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));                              
             }
             $('#CVV').parents('.form-group').show();
-            $('#CancelUpdateText').parents('.form-group').show();
+            showSavePayUncheckedBox();
         });
         $('#CancelUpdateText').click(function () {
             CancelCreditCardInfoUpdate();
         });
+    }
+
+    if ($('#Routing').length) {
+        $('#Routing').change(function () {
+            if ($('#Routing').val().startsWith('X')) {
+                $('#Routing').val($('#Routing').val().replace('X', 'Y'));
+            }
+            showSavePayUncheckedBox();
+        });
+        $('#Account').change(function () {
+            if ($('#Routing').val().startsWith('X')) {
+                $('#Routing').val($('#Routing').val().replace('X', 'Y'));
+            }
+            showSavePayUncheckedBox();
+        });
+    }
+
+    function showSavePayUncheckedBox() {
+        $('#CancelUpdateText').parents('.form-group').show();
+        $('#savePayArea').show();
+        $('#SavePayInfo').prop('checked', false);
     }
 
     function CancelCreditCardInfoUpdate() {
@@ -246,7 +306,7 @@ $(function () {
     }
     
     if ($("#allowcc").val()) {
-        $.ShowPaymentInfo($("input[name=Type]:checked").val());
+        $.ShowPaymentInfo2($("input[name=Type]:checked").val());
     }
     var repeatPattern = $("select[name=RepeatPattern]").val();
     $.SetSemiEvery(repeatPattern);

--- a/CmsWeb/Content/touchpoint/js/onlinereg/OnlineRegPayment2.js
+++ b/CmsWeb/Content/touchpoint/js/onlinereg/OnlineRegPayment2.js
@@ -12,6 +12,7 @@ $(function () {
         return false;
     });
     $("#formerror").hide();
+    $("#savePayArea").hide();
     $("a.submitbutton, a.submitlink").click(function (ev) {
         ev.preventDefault();
         if (!agreeterms) {
@@ -201,12 +202,16 @@ $(function () {
             $('#CVV').parents('.form-group').show();
             if ($('#CreditCard').val().startsWith('X')) {
                 $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));
+                $('#savePayArea').show();
+                $('#SavePayInfo').prop('checked', false);
             }
             $('#CancelUpdateText').parents('.form-group').show();
         });
         $('#Expires').change(function () {
             if ($('#CreditCard').val().startsWith('X')) {
                 $('#CreditCard').val($('#CreditCard').val().replace('X', 'Y'));
+                $('#savePayArea').show();
+                $('#SavePayInfo').prop('checked',false);               
             }
             $('#CVV').parents('.form-group').show();
             $('#CancelUpdateText').parents('.form-group').show();

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -44,7 +44,7 @@
     <!-- use (local) or .\SQLEXPRESS -->
     <add key="dbserver" value="(local)"/>
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="bellevue"/>
+    <add key="host" value="testdb"/>
   </appSettings>
   <connectionStrings configSource="ConnectionStrings.config"/>
   <!--
@@ -738,7 +738,7 @@
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">
-        <specifiedPickupDirectory pickupDirectoryLocation="c:\email"/>
+        <specifiedPickupDirectory pickupDirectoryLocation="C:\bvcms\email"/>
         <network host="localhost"/>
       </smtp>
       <!--<smtp from="somebody@nowhere.com">

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -44,7 +44,7 @@
     <!-- use (local) or .\SQLEXPRESS -->
     <add key="dbserver" value="(local)"/>
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="testdb"/>
+    <add key="host" value="bellevue"/>
   </appSettings>
   <connectionStrings configSource="ConnectionStrings.config"/>
   <!--
@@ -738,7 +738,7 @@
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">
-        <specifiedPickupDirectory pickupDirectoryLocation="C:\bvcms\email"/>
+        <specifiedPickupDirectory pickupDirectoryLocation="C:\email"/>
         <network host="localhost"/>
       </smtp>
       <!--<smtp from="somebody@nowhere.com">

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -738,7 +738,7 @@
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">
-        <specifiedPickupDirectory pickupDirectoryLocation="C:\email"/>
+        <specifiedPickupDirectory pickupDirectoryLocation="c:\email"/>
         <network host="localhost"/>
       </smtp>
       <!--<smtp from="somebody@nowhere.com">


### PR DESCRIPTION
In OneTimeGiving, and OnePageGiving, "Save Payment Information" checkbox is hidden now when payment information is already saved in DB. If User modifies this payment information checkbox shows up as unchecked forcing the user to consciously check the box if she wants to save it.