### PR TITLE
SFG Map Error

### DIFF
--- a/CmsWeb/Areas/Public/Models/SGMapModel.cs
+++ b/CmsWeb/Areas/Public/Models/SGMapModel.cs
@@ -121,7 +121,7 @@ namespace CmsWeb.Models
 
             var addlist = new List<GeoCode>();
 
-            foreach (var i in qlist.Where(ii => ii.gc == null))
+            foreach (var i in qlist)
             {
                 i.gc = addlist.SingleOrDefault(g => g.Address == i.addr)
                     ?? DbUtil.Db.GeoCodes.FirstOrDefault(g => g.Address == i.addr);
@@ -130,7 +130,13 @@ namespace CmsWeb.Models
                     i.gc = GetGeocode(i.addr);
                     addlist.Add(i.gc);
                 }
-            }
+                else if(i.gc.Latitude == 0)
+                {
+                    GeoCode gcMod = GetGeocode(i.addr);
+                    i.gc.Latitude = gcMod.Latitude;
+                    i.gc.Longitude = gcMod.Longitude;
+                }               
+            }            
             if (addlist.Count > 0)
                 DbUtil.Db.GeoCodes.InsertAllOnSubmit(addlist);
             DbUtil.Db.SubmitChanges();


### PR DESCRIPTION
I have used all the addresses that the Trello card description mentioned (Including "240 Baldwin Ln, Christiansburg, VA 24073-4414") and all of them have returned the same coordinates and show me the map marker correctly.

However, I noticed something interesting that could be the reason for this issue.
When, for any reason, your API Key is expired or not have permission for Google our application is storing in DB the coordinates 0,0 for that address. Then, when you tried to show the map once again, the application doesn't ask to google for other coordinates but use what is in DB (in this case 0,0) so, doesn't show in the map nor in the groups.
I made a little modification to verify if the coordinates stored are 0,0, if it is the case, then ask again to Google API. I hope this solves the issue.
Please, take a look at your API Key to be sure that still working and you have it set properly in the application.