### PR TITLE
Fix member moved from member dialog box.

### DIFF
--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -783,11 +783,7 @@ AND a.PeopleId = {2}
 
             if (om.OrganizationId != tom.OrganizationId)
                 tom.Moved = true;
-            om.Drop(db, skipTriggerProcessing: true);
-
-            //Once member has been inserted into the new Organization then update member in Organizations as enrolled / not enrolled accordingly
-            db.RepairTransactions(fromOrg);
-            db.RepairTransactions(toOrg);
+            om.Drop(db, skipTriggerProcessing: true);            
             db.SubmitChanges();
         }
     }

--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -784,6 +784,10 @@ AND a.PeopleId = {2}
             if (om.OrganizationId != tom.OrganizationId)
                 tom.Moved = true;
             om.Drop(db, skipTriggerProcessing: true);
+
+            //Once member has been inserted into the new Organization then update member in Organizations as enrolled / not enrolled accordingly
+            db.RepairTransactions(fromOrg);
+            db.RepairTransactions(toOrg);
             db.SubmitChanges();
         }
     }

--- a/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
@@ -76,8 +76,6 @@ namespace CmsWeb.Areas.Dialog.Models
                 if (oid == model.TargetId)
                     continue;
                 OrganizationMember.MoveToOrg(db, pid, oid, model.TargetId, model.MoveRegistrationData, model.ChangeMemberType == true ? model.MoveToMemberTypeId : -1);
-                //Once member has been inserted into the new Organization then update member  in Previous Organization as not enrolled.
-                db.RepairTransactions(oid);
                 lop = FetchLongRunningOperation(db, Op, model.QueryId);
                 Debug.Assert(lop != null, "r != null");
                 lop.Processed++;

--- a/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
@@ -76,6 +76,9 @@ namespace CmsWeb.Areas.Dialog.Models
                 if (oid == model.TargetId)
                     continue;
                 OrganizationMember.MoveToOrg(db, pid, oid, model.TargetId, model.MoveRegistrationData, model.ChangeMemberType == true ? model.MoveToMemberTypeId : -1);
+                //Once member has been inserted into the new Organization then update member in Organizations as enrolled / not enrolled accordingly
+                db.RepairTransactions(oid);
+                db.RepairTransactions(model.TargetId);
                 lop = FetchLongRunningOperation(db, Op, model.QueryId);
                 Debug.Assert(lop != null, "r != null");
                 lop.Processed++;

--- a/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
@@ -96,7 +96,10 @@ namespace CmsWeb.Areas.Dialog.Models
         {
             if (!PeopleId.HasValue || !OrgId.HasValue)
                 return "not moved";
-            OrganizationMember.MoveToOrg(DbUtil.Db, PeopleId.Value, OrgId.Value, toid, MoveRegistrationData);           
+            OrganizationMember.MoveToOrg(DbUtil.Db, PeopleId.Value, OrgId.Value, toid, MoveRegistrationData);
+            //Once member has been inserted into the new Organization then update member in Organizations as enrolled / not enrolled accordingly
+            DbUtil.Db.RepairTransactions(OrgId.Value);
+            DbUtil.Db.RepairTransactions(toid);
             DbUtil.LogActivity("OrgMem Move to " + toid, OrgId, PeopleId);
             return "moved";
         }

--- a/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
@@ -97,6 +97,7 @@ namespace CmsWeb.Areas.Dialog.Models
             if (!PeopleId.HasValue || !OrgId.HasValue)
                 return "not moved";
             OrganizationMember.MoveToOrg(DbUtil.Db, PeopleId.Value, OrgId.Value, toid, MoveRegistrationData);
+            DbUtil.Db.RepairTransactions(OrgId.Value);
             DbUtil.LogActivity("OrgMem Move to " + toid, OrgId, PeopleId);
             return "moved";
         }

--- a/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/OrgMember/OrgMemberMoveModel.cs
@@ -96,8 +96,7 @@ namespace CmsWeb.Areas.Dialog.Models
         {
             if (!PeopleId.HasValue || !OrgId.HasValue)
                 return "not moved";
-            OrganizationMember.MoveToOrg(DbUtil.Db, PeopleId.Value, OrgId.Value, toid, MoveRegistrationData);
-            DbUtil.Db.RepairTransactions(OrgId.Value);
+            OrganizationMember.MoveToOrg(DbUtil.Db, PeopleId.Value, OrgId.Value, toid, MoveRegistrationData);           
             DbUtil.LogActivity("OrgMem Move to " + toid, OrgId, PeopleId);
             return "moved";
         }


### PR DESCRIPTION
The process of moving an individual to a different oganization using move member dialog window is fixed running repair transactions in previous organization to remove references in meeting attendance list.