### PR TITLE
hide name field and role selector from the default email template

### DIFF
--- a/CmsWeb/Areas/Manage/Views/Display/EditTemplate.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Display/EditTemplate.cshtml
@@ -14,7 +14,7 @@
           <div class="box-content">
             <div class="row">
               <div class="col-sm-4">
-                <div class="form-group">
+                <div class="@((Model.Name == "Empty Template") ? "hidden" : "form-group")">
                   <label for="name" class="control-label">Name</label>
                   @Html.TextBox("name", Model.Name, new { @class = "form-control" })
                 </div>
@@ -22,7 +22,7 @@
                   <label for="title" class="control-label">Title</label>
                   @Html.TextBox("title", Model.Title, new { @class = "form-control" })
                 </div>
-                <div class="form-group">
+                <div class="@((Model.Name == "Empty Template") ? "hidden" : "form-group")">
                   <label for="role" class="control-label">Role</label>
                   @Html.DropDownList("roleid", new SelectList(ContentModel.fetchRoles(), "RoleId", "RoleName"), new { @class = "form-control" })
                 </div>


### PR DESCRIPTION
https://trello.com/c/136fdbQR/5190-email-template-with-role-assigned-to-it-is-giving-everyone-access-instead-of-the-individuals-with-the-specific-role