### PR TITLE
Fix members with null enrollment date

### DIFF
--- a/CmsData/CmsData.csproj
+++ b/CmsData/CmsData.csproj
@@ -1320,6 +1320,7 @@
     <Content Include="Migrations\20181115_add_recurring_amounts_disabled_column.sql" />
     <Content Include="Migrations\20181120_Update_GetContributionDetails_func.sql" />
     <Content Include="Migrations\20181206_create_RemoveFromEnrollmentHistory_proc.sql" />
+    <Content Include="Migrations\20190106_ja-members-null-enrollmentdate-fix.sql" />
     <Content Include="Migrations\20181218_ja-members-not-included-attendance-fix.sql" />
     <Content Include="Migrations\20181211_update_inactive_recurring_amounts.sql" />
     <Content Include="Migrations\20181205_create_CreateZipCodesRange_proc.sql" />

--- a/CmsData/Migrations/20190106_ja-members-null-enrollmentdate-fix.sql
+++ b/CmsData/Migrations/20190106_ja-members-null-enrollmentdate-fix.sql
@@ -1,0 +1,19 @@
+IF EXISTS (SELECT * FROM sysobjects WHERE id = object_id(N'[dbo].[RepairEnrollmentDate]') AND OBJECTPROPERTY(id, N'IsProcedure') = 1)
+BEGIN
+    DROP PROCEDURE [dbo].[RepairEnrollmentDate]
+END
+GO
+
+CREATE PROC [dbo].[RepairEnrollmentDate](@orgID INT)
+AS
+BEGIN
+    UPDATE om
+    SET	om.EnrollmentDate = DATEADD(SECOND,1,isnull(om.EnrollmentDate, om.createddate))
+    --SELECT OM.ORGANIZATIONID, OM.PEOPLEID, OM.ENROLLMENTDATE, ET.ENROLLMENTDATE 
+    FROM
+        dbo.OrganizationMembers AS om
+        left outer join EnrollmentTransaction et ON om.OrganizationId = et.OrganizationId and om.PeopleId = et.PeopleId 
+   WHERE om.Organizationid = @orgID AND et.EnrollmentDate is null
+    
+END
+GO


### PR DESCRIPTION
Updating procedure [RepairEnrollmentDate] to take createddate when enrollmentdate is null.

Migration: 20190106_ja-members-null-enrollmentdate-fix.sql
Line 11
*isnull(om.EnrollmentDate, om.createddate)*