### PR TITLE
Offset days by 7 to allow nonbatched transactions time to settle and be included in reports using batchdates

### DIFF
--- a/CmsWeb/Areas/Manage/Models/TransactionsModel.cs
+++ b/CmsWeb/Areas/Manage/Models/TransactionsModel.cs
@@ -158,7 +158,8 @@ namespace CmsWeb.Models
             edt = edt?.AddHours(24);
             if (usebatchdates && startdt.HasValue && edt.HasValue)
             {
-                CheckBatchDates(startdt.Value, edt.Value);
+                // Apply an offset to the startdate to get those records that occurred prior to the batch date and haven't been batched at present
+                CheckBatchDates(startdt.Value.AddDays(-7), edt.Value);
                 _transactions = from t in _transactions
                                 where t.Batch >= startdt || startdt == null
                                 where t.Batch <= edt || edt == null


### PR DESCRIPTION
https://trello.com/c/yZ52ygbA/5246-bug-inconsistencies-with-the-reconcile-report-when-using-batch-date