### PR TITLE
Updating expression ContributionAmountBothJointHistory.

### DIFF
--- a/CmsData/QueryBuilder/Expressions/Contributions.cs
+++ b/CmsData/QueryBuilder/Expressions/Contributions.cs
@@ -335,19 +335,7 @@ namespace CmsData
         }
         internal Expression ContributionAmountBothJointHistory()
         {
-            DateTime? enddt = null;
-            if (!EndDate.HasValue && StartDate.HasValue)
-            {
-                enddt = StartDate.Value.AddHours(24);
-            }
-
-            if (EndDate.HasValue)
-            {
-                enddt = EndDate.Value.AddHours(24);
-            }
-
-            return ContributionAmountBothJoint(StartDate, enddt);
-
+            return ContributionAmountBothJoint(StartDate, EndDate);
         }
         internal Expression ContributionAmountSinceSetting()
         {


### PR DESCRIPTION
It was possible to see contributions one day ahead in the future out of the date range because an extra 24 hrs were being added both in code and also inside SQL functions. Fixed now.