### PR TITLE
Performance: Move Org Members

### DIFF
--- a/CmsWeb/Areas/Dialog/Controllers/MoveOrgMembersController.cs
+++ b/CmsWeb/Areas/Dialog/Controllers/MoveOrgMembersController.cs
@@ -23,16 +23,18 @@ namespace CmsWeb.Areas.Dialog.Controllers
         {
             model.UpdateLongRunningOp(CurrentDatabase, MoveOrgMembersModel.Op);
 
-            if (!model.Started.HasValue)
+            if (model.Started.HasValue)
             {
-                if (model.TargetId == 0)
-                {
-                    return Content("!Target required");
-                }
-
-                DbUtil.LogActivity("Move Org Members");
-                model.ProcessMove(CurrentDatabase);
+                return View(model);
             }
+
+            if (model.TargetId == 0)
+            {
+                return Content("!Target required");
+            }
+
+            DbUtil.LogActivity("Move Org Members");
+            model.ProcessMove(CurrentDatabase);
             return View(model);
         }
     }

--- a/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
+++ b/CmsWeb/Areas/Dialog/Models/MoveOrgMembersModel.cs
@@ -58,14 +58,15 @@ namespace CmsWeb.Areas.Dialog.Models
         }
         public static void DoMoveWork(MoveOrgMembersModel model)
         {
-            var db = DbUtil.Create(model.Host);
-            db.CommandTimeout = 2200;
-            var cul = db.Setting("Culture", "en-US");
+            var jobStatusContext = DbUtil.Create(model.Host);
+            var jobWorkerContext = DbUtil.Create(model.Host);
+            jobWorkerContext.CommandTimeout = 2200;
+            var cul = jobWorkerContext.Setting("Culture", "en-US");
             Thread.CurrentThread.CurrentUICulture = new CultureInfo(cul);
             Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(cul);
             LongRunningOperation lop = null;
 
-            foreach (var i in model.List)
+            foreach (var i in model.List) // {personId}.{organizationId}
             {
                 var a = i.Split('.');
                 if (a.Length != 2)
@@ -81,21 +82,21 @@ namespace CmsWeb.Areas.Dialog.Models
                     continue;
                 }
 
-                OrganizationMember.MoveToOrg(db, pid, oid, model.TargetId, model.MoveRegistrationData, model.ChangeMemberType == true ? model.MoveToMemberTypeId : -1);
+                OrganizationMember.MoveToOrg(jobWorkerContext, pid, oid, model.TargetId, model.MoveRegistrationData, model.ChangeMemberType == true ? model.MoveToMemberTypeId : -1);
                 //Once member has been inserted into the new Organization then update member in Organizations as enrolled / not enrolled accordingly
-                db.RepairTransactions(oid);
-                db.RepairTransactions(model.TargetId);
-                lop = FetchLongRunningOperation(db, Op, model.QueryId);
+                jobWorkerContext.RepairTransactions(oid);
+                jobWorkerContext.RepairTransactions(model.TargetId);
+                lop = FetchLongRunningOperation(jobStatusContext, Op, model.QueryId);
                 Debug.Assert(lop != null, "r != null");
                 lop.Processed++;
                 lop.CustomMessage = $"Working from {pid},{oid} to {model.TargetId}";
-                db.SubmitChanges();
+                jobStatusContext.SubmitChanges();
             }
             // finished
-            lop = FetchLongRunningOperation(db, Op, model.QueryId);
+            lop = FetchLongRunningOperation(jobStatusContext, Op, model.QueryId);
             lop.Completed = DateTime.Now;
-            db.SubmitChanges();
-            db.UpdateMainFellowship(model.TargetId);
+            jobStatusContext.SubmitChanges();
+            jobWorkerContext.UpdateMainFellowship(model.TargetId);
         }
     }
 }


### PR DESCRIPTION
Reduce db trips by putting the long running operation status updates on a separate context avoding SubmitChanges from saving before required.

https://trello.com/c/Nb6D1cGF/5290-slowness-at-bellevue-moving-org-members-is-processing-slowly