### PR TITLE
Contribution Search should support using QueryTags as a filter

### DIFF
--- a/CmsData/API/QueryFunctions/Query.cs
+++ b/CmsData/API/QueryFunctions/Query.cs
@@ -143,7 +143,12 @@ namespace CmsData
             var cn = GetReadonlyConnection();
             var parameters = new DynamicParameters();
             if (declarations != null)
+            {
                 AddParameters(declarations, parameters);
+#if DEBUG
+                sql = RemoveDeclarations(declarations, sql);
+#endif
+            }
             ApplyStandardParameters(sql, parameters);
             return cn.Query(sql, parameters, commandTimeout: 300);
         }
@@ -155,7 +160,12 @@ namespace CmsData
             if (p1 != null)
                 sql = AddP1Parameter(sql, p1, parameters);
             if (declarations != null)
+            {
                 AddParameters(declarations, parameters);
+#if DEBUG
+                sql = RemoveDeclarations(declarations, sql);
+#endif
+            }
             ApplyStandardParameters(sql, parameters);
 
             return cn.Query(sql, parameters, commandTimeout: 300);
@@ -193,6 +203,31 @@ namespace CmsData
             else
                 parameters.Add("@p1", declarations ?? "");
         }
+
+        private static string RemoveDeclaration(object decl, string body)
+        {
+            return Regex.Replace(body, $"^declare @{decl}", "--$&", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        }
+#if DEBUG
+        private static string RemoveDeclarations(object declarations, string body)
+        {
+            var pd = declarations as PythonDictionary;
+            var dd = declarations as DynamicData;
+            var ds = declarations as Dictionary<string, string>;
+            if (pd != null)
+                foreach (var kv in pd)
+                    body = RemoveDeclaration(kv.Key, body);
+            else if (dd != null)
+                foreach (var kv in dd.dict)
+                    body = RemoveDeclaration(kv.Key, body);
+            else if (ds != null)
+                foreach (var kv in ds)
+                    body = RemoveDeclaration(kv.Key, body);
+            else
+                body = RemoveDeclaration("p1", body);
+            return body;
+        }
+#endif
 
         private void ApplyStandardParameters(string sql, DynamicParameters parameters)
         {
@@ -341,7 +376,12 @@ namespace CmsData
             var cn = GetReadonlyConnection();
             var parameters = new DynamicParameters();
             if (declarations != null)
+            {
                 AddParameters(declarations, parameters);
+#if DEBUG
+                sql = RemoveDeclarations(declarations, sql);
+#endif
+            }
             var ret = new DynamicData();
             using (var rd = cn.ExecuteReader(sql, parameters))
             {
@@ -350,7 +390,20 @@ namespace CmsData
                 {
                     var dd = new DynamicData();
                     for (var i = 0; i < rd.FieldCount; i++)
-                        dd.AddValue(rd.GetName(i), rd.GetValue(i));
+                    {
+                        var t = rd.GetDataTypeName(i);
+                        switch (t)
+                        {
+                            case "datetime":
+                                var dt = rd.GetDateTime(i);
+                                var fmt = dt.TimeOfDay.Equals(TimeSpan.Zero) ? "d" : "g";
+                                dd.AddValue(rd.GetName(i), dt.ToString(fmt));
+                                break;
+                            default:
+                                dd.AddValue(rd.GetName(i), rd.GetValue(i));
+                                break;
+                        }
+                    }
                     ret.AddValue(rd.GetString(0), dd);
                     maxn--;
                     if (maxn == 0)

--- a/CmsData/DbUtil/Context.cs
+++ b/CmsData/DbUtil/Context.cs
@@ -594,6 +594,11 @@ This search uses multiple steps which cannot be duplicated in a single query.
         }
         public Tag TagCurrent()
         {
+            if (Util2.CurrentTag.StartsWith("QueryTag:"))
+            {
+                return Tags.FirstOrDefault(t =>
+                    t.Name == Util2.CurrentTagName && t.TypeId == DbUtil.TagTypeId_QueryTags);
+            }
             return FetchOrCreateTag(Util2.CurrentTagName, Util2.CurrentTagOwnerId, DbUtil.TagTypeId_Personal);
         }
         //public string NewPeopleEmailAddressx

--- a/CmsData/DbUtil/Session.cs
+++ b/CmsData/DbUtil/Session.cs
@@ -134,6 +134,10 @@ namespace CmsData
         {
             get
             {
+                if (CurrentTag.StartsWith("QueryTag:"))
+                {
+                    return CurrentTag.GetCsvToken(2, 2, ":");
+                }
                 string tag = CurrentTag;
                 var a = tag.Split('!');
                 if(a[0].ToInt2() > 0)

--- a/CmsWeb/Areas/Finance/Controllers/ContributionsController.cs
+++ b/CmsWeb/Areas/Finance/Controllers/ContributionsController.cs
@@ -3,6 +3,7 @@ using CmsWeb.Lifecycle;
 using System;
 using System.Web.Mvc;
 using System.Web.Routing;
+using CmsData;
 using UtilityExtensions;
 using ContributionSearchModel = CmsWeb.Models.ContributionSearchModel;
 
@@ -18,8 +19,11 @@ namespace CmsWeb.Areas.Finance.Controllers
 
         [Route("~/Contributions/{id:int?}")]
         public ActionResult Index(int? id, int? year, int? fundId, DateTime? dt1, DateTime? dt2, int? campus, int? bundletype,
-            bool? includeunclosedbundles = true, int online = 2, string taxnontax = "TaxDed", string fundSet = null)
+            bool? includeunclosedbundles = true, int online = 2, string taxnontax = "TaxDed", string fundSet = null, 
+			bool filterbyactivetag = false, string setQueryTag = null)
         {
+            if (setQueryTag.HasValue())
+                Util2.CurrentTag = $"QueryTag:{setQueryTag}";
             var api = new ContributionSearchInfo()
             {
                 PeopleId = id,
@@ -31,7 +35,8 @@ namespace CmsWeb.Areas.Finance.Controllers
                 Online = online,
                 TaxNonTax = taxnontax,
                 IncludeUnclosedBundles = includeunclosedbundles ?? false,
-                BundleType = bundletype
+                BundleType = bundletype,
+                FilterByActiveTag = filterbyactivetag
             };
 
             // Only setting it like this for debug purpose

--- a/CmsWeb/Areas/Finance/Views/Contributions/Index.cshtml
+++ b/CmsWeb/Areas/Finance/Views/Contributions/Index.cshtml
@@ -147,6 +147,11 @@
                                     @Html.CheckBoxFor(vv => vv.SearchInfo.Mobile) From mobile application?
                                 </label>
                             </div>
+                            <div class="checkbox">
+                                <label class="control-label">
+                                    @Html.CheckBoxFor(vv => vv.SearchInfo.FilterByActiveTag) Filter by Active Tag?
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/CmsWeb/Models/ScriptModel.cs
+++ b/CmsWeb/Models/ScriptModel.cs
@@ -79,11 +79,17 @@ namespace CmsWeb.Models
             if (body.Contains("@StartDt"))
             {
                 p.Add("@StartDt", new DateTime(DateTime.Now.Year, 1, 1));
+#if DEBUG
+                body = Regex.Replace(body, "^declare @StartDt", "--$&", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+#endif
             }
 
             if (body.Contains("@EndDt"))
             {
                 p.Add("@EndDt", DateTime.Today);
+#if DEBUG
+                body = Regex.Replace(body, "^declare @EndDt", "--$&", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+#endif
             }
 
             if (body.Contains("@userid", ignoreCase: true))


### PR DESCRIPTION
Contribution Search can filter by a normal Tag. This PR allows filtering by a QueryTag too.
QueryTag is a special type of tag that is only created via the PythonModel. It is used for caching a list of people for fast reporting and for easy validation and reconcilation. A QueryTag can be searched with SearchBuilder but it would be very helpful to filter contributions by the people in a QueryTag.
The only way to set a QueryTag as the active Tag is via a QueryString on the Contribution search URL called setQueryTag. This allows a link to be on the report that will go directly to the Contribution Search and run giving a total that should match up with the report.