### PR TITLE
fix off by 1 error in footer

### DIFF
--- a/CmsWeb/Areas/Reports/Models/Other/HeadFoot.cs
+++ b/CmsWeb/Areas/Reports/Models/Other/HeadFoot.cs
@@ -75,7 +75,7 @@ namespace CmsWeb.Areas.Reports.Models
             {
                 tpl.BeginText();
                 tpl.SetFontAndSize(font, 8);
-                tpl.ShowText((writer.PageNumber - 1).ToString());
+                tpl.ShowText(writer.PageNumber.ToString());
                 tpl.EndText();
                 base.OnCloseDocument(writer, document);
             }


### PR DESCRIPTION
https://trello.com/c/sgShGIDc/5413-bug-the-recent-attendance-report-is-showing-page-numbers-in-the-footer-from-1-of-7-to-8-of-7-when-there-are-8-pages