### PR TITLE
Preserving admin variable value when being accessed by objects of type PagedTableModel.

### DIFF
--- a/CmsWeb/Areas/Search/Models/SavedQuery/SavedQueryModel.cs
+++ b/CmsWeb/Areas/Search/Models/SavedQuery/SavedQueryModel.cs
@@ -31,6 +31,7 @@ namespace CmsWeb.Areas.Search.Models
 
         public override IQueryable<Query> DefineModelList()
         {
+            admin = Roles.IsUserInRole("Admin");
             var q = from c in Db.Queries
                     where !PublicOnly || c.Ispublic
                     where c.Name.Contains(SearchQuery) || c.Owner == SearchQuery || !SearchQuery.HasValue()
@@ -66,7 +67,7 @@ namespace CmsWeb.Areas.Search.Models
             else if (!admin)
             {
                 q = from c in q
-                    where c.Owner == Util.UserName || c.Ispublic
+                    where c.Owner.ToUpper() == Util.UserName.ToUpper() || c.Ispublic
                     select c;
             }
 


### PR DESCRIPTION
Support issue.

Trigger: When a header click happens in Saved Search Queries table headers. 
Issue: Object PagedTableModel is executing public method DefineModelList() without assigning admin variable value. Query search was filtering by owner if !admin.
FIX: Set admin value at the beginning of method DefineModelList().