### PR TITLE
Show records with createdby of 0, tag as onlinereg

### DIFF
--- a/CmsWeb/Areas/People/Views/Person/Personal/Display.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Personal/Display.cshtml
@@ -105,9 +105,16 @@
   <p class="record_added muted">
     <small>
       Record added @Model.CreatedDate.FormatDateTm()
-      @if (Model.person.CreatedBy != 0 && ((User.IsInRole("Edit") || User.IsInRole("Admin"))))
+      @if (((User.IsInRole("Edit") || User.IsInRole("Admin"))))
       {
-          @:(<a href="/Person2/User/@Model.person.CreatedBy">@Model.person.CreatedBy</a>)
+          if(Model.person.CreatedBy == 0)
+          {
+              @:(OnlineReg)
+          }
+          else
+          {
+            @:(<a href="/Person2/User/@Model.person.CreatedBy">@Model.person.CreatedBy</a>)
+          }
       }
     </small>
   </p>


### PR DESCRIPTION
Well, this ended up being much easier then I was making it out to be... 🤒 This works and reenables the display to designate the record came from online reg. However, unless a user is logged in already during the registration process the user id is still going to be recorded as 0 which means the actual link itself would render an error that says "no person found." Based on the ask, I am assuming this is a desired feature.

I would like to keep the other branch with many more changes in it and continue to refactor this process more there in the future (time permitting when I get caught up). There are many things cleaned up there that I believe would help fix a few intermittent issues with online reg, including possibly submitting some data or running some important methods twice resulting in duplicates (note: paymentform.cs in particular). However, for the ticket concerning this, this change is the only one required to move this ticket to done. My apologies for the delay.