### PR TITLE
Add a filter for transactions that include the additional donation am…

### DIFF
--- a/CmsWeb/Areas/Manage/Controllers/TransactionsController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/TransactionsController.cs
@@ -45,6 +45,12 @@ namespace CmsWeb.Areas.Manage.Controllers
         }
 
         [HttpPost]
+        public ActionResult TransactionsWithExtraDonationAmount(TransactionsModel m)
+        {
+            return View(m);
+        }
+
+        [HttpPost]
         public ActionResult List(TransactionsModel m)
         {
             UpdateModel(m.Pager);
@@ -178,7 +184,7 @@ namespace CmsWeb.Areas.Manage.Controllers
 <tr><td>Date</td><td>{t.TransactionDate.FormatDateTm()}</td></tr>
 <tr><td>TranIds</td><td>Org: {t.Id} {t.TransactionId}, Curr: {transaction.Id} {transaction.TransactionId}</td></tr>
 <tr><td>User</td><td>{Util.UserFullName}</td></tr>
-</table>", Util.EmailAddressListFromString(CurrentDatabase.StaffEmailForOrg(transaction.OrgId ?? 0)));            
+</table>", Util.EmailAddressListFromString(CurrentDatabase.StaffEmailForOrg(transaction.OrgId ?? 0)));
 
             return View("List", m);
         }

--- a/CmsWeb/Areas/Manage/Models/TransactionsModel.cs
+++ b/CmsWeb/Areas/Manage/Models/TransactionsModel.cs
@@ -53,6 +53,7 @@ namespace CmsWeb.Models
         public DateTime? enddt { get; set; }
         public bool testtransactions { get; set; }
         public bool apprtransactions { get; set; }
+        public bool includesadditionaldonation { get; set; }
         public bool nocoupons { get; set; }
         public string batchref { get; set; }
         public bool usebatchdates { get; set; }
@@ -172,6 +173,11 @@ namespace CmsWeb.Models
                                 where t.TransactionDate >= startdt || startdt == null
                                 where t.TransactionDate <= edt || edt == null
                                 select t;
+            }
+
+            if (includesadditionaldonation)
+            {
+                _transactions = _transactions.Where(t => t.Donate > 0.00m);
             }
             //			var q0 = _transactions.ToList();
             //            foreach(var t in q0)
@@ -405,6 +411,7 @@ namespace CmsWeb.Models
                        TripName = o.OrganizationName
                    };
         }
+
         public List<MissionTripBalanceInfo> MissionTripBalances()
         {
             var q = from gs in DbUtil.Db.GoerSenderAmounts
@@ -511,6 +518,7 @@ namespace CmsWeb.Models
             public int? OrgId { get; set; }
             public string TripName { get; set; }
         }
+
         public class MissionTripBalanceInfo
         {
             public int GoerId { get; set; }

--- a/CmsWeb/Areas/Manage/Views/Transactions/Index.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Transactions/Index.cshtml
@@ -90,6 +90,11 @@
                   @Html.CheckBox("testtransactions") Test transactions only?
                 </label>
               </div>
+              <div class="checkbox">
+                  <label class="control-label">
+                      @Html.CheckBox("includesadditionaldonation") Includes additional donation?
+                  </label>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
…ount. Leaving it unchecked gives the same results as current, this simply gives the option to only show those that have an extra amount for assistance with accounting purposes.

https://trello.com/c/R0Ggx85b/5309-hidden-donations-in-totals-by-description-reports-martha-witcher-bellevue-31942