### PR TITLE
fix null pointer exception when running registration report on previous members of an org

### DIFF
--- a/CmsWeb/Areas/Reports/Models/Enrollment/RegistrationResult.cs
+++ b/CmsWeb/Areas/Reports/Models/Enrollment/RegistrationResult.cs
@@ -465,7 +465,8 @@ namespace CmsWeb.Areas.Reports.Models
 
                 if (x.Organization == null || SettingVisible(setting, "AskRequest"))
                 {
-                    AddValue(table, row, ((AskRequest)setting.AskItem("AskRequest")).Label, x.OrgMembers?.Request);
+                    var label = ((AskRequest)setting?.AskItem("AskRequest"))?.Label ?? "Request";
+                    AddValue(table, row, label, x.OrgMembers?.Request);
                 }
 
                 AddValue(table, row, "Allergies", x.RecReg.MedicalDescription);


### PR DESCRIPTION
https://trello.com/c/l8XK3VWw/4471-bug-registration-report-excel-produces-error-when-running-for-previous-members