### PR TITLE
Remove online reg designation from person display and return to showing 0 without an error link.

### DIFF
--- a/CmsWeb/Areas/People/Views/Person/Personal/Display.cshtml
+++ b/CmsWeb/Areas/People/Views/Person/Personal/Display.cshtml
@@ -109,7 +109,7 @@
       {
           if(Model.person.CreatedBy == 0)
           {
-              @:(OnlineReg)
+              @:(0)
           }
           else
           {


### PR DESCRIPTION
Change requested by Brett.