### PR TITLE
Fix "There is already an open DataReader associated with this Command…

### DIFF
--- a/CmsData/API/QueryFunctions/Query.cs
+++ b/CmsData/API/QueryFunctions/Query.cs
@@ -355,11 +355,14 @@ namespace CmsData
         /// </summary>
         public DynamicData SqlNameValues(string sql, string NameCol, string ValueCol)
         {
-            var rd = db.Connection.ExecuteReader(sql);
-            var dd = new DynamicData();
-            while (rd.Read())
-                dd.dict.Add(rd[NameCol].ToString(), rd[ValueCol]);
-            return dd;
+            var cn = GetReadonlyConnection();
+            using (var rd = cn.ExecuteReader(sql))
+            {
+                var dd = new DynamicData();
+                while (rd.Read())
+                    dd.dict.Add(rd[NameCol].ToString(), rd[ValueCol]);
+                return dd;
+            }
         }
 
         /// <summary>

--- a/CmsData/DbUtil/Context.cs
+++ b/CmsData/DbUtil/Context.cs
@@ -1575,7 +1575,7 @@ This search uses multiple steps which cannot be duplicated in a single query.
         }
         public Content Content(string name, string defaultValue, int contentTypeId)
         {
-            var c = Contents.FirstOrDefault(cc => cc.Name == name);
+            var c = Contents.FirstOrDefault(cc => cc.Name == name && cc.TypeID == contentTypeId);
             if (c != null)
             {
                 return c;


### PR DESCRIPTION
Fix "There is already an open DataReader associated with this Command which must be closed first.

This error recently started popping up with a Python report on Mount Pisgah that was using the `q.SqlNameValues()` function. Needed to make sure the ExecuteReader was closed and disposed before moving on. This bug is preventing the client from running a critical report.