### PR TITLE
Move Copy() call inside the PythonModel constructor

### DIFF
--- a/CmsData/API/PythonModel/Internal.cs
+++ b/CmsData/API/PythonModel/Internal.cs
@@ -11,8 +11,7 @@ using Microsoft.Scripting.Hosting;
 using Microsoft.Scripting.Hosting.Providers;
 
 namespace CmsData
-{
-    public partial class PythonModel
+{public partial class PythonModel
     {
         // ReSharper disable InconsistentNaming
         private readonly CMSDataContext db;
@@ -41,14 +40,14 @@ namespace CmsData
         
         public PythonModel(CMSDataContext dbContext)
         {
-            db = dbContext;
+            db = dbContext.Copy();
             dictionary = new Dictionary<string, object>();
             Data = new DynamicData(dictionary);
         }
 
         public PythonModel(CMSDataContext dbContext, Dictionary<string, object> dict)
         {
-            db = dbContext;
+            db = dbContext.Copy();
             dictionary = dict;
             Data = new DynamicData(dictionary);
         }

--- a/CmsData/API/PythonModel/Misc.cs
+++ b/CmsData/API/PythonModel/Misc.cs
@@ -36,7 +36,7 @@ namespace CmsData
         public string CallScript(string scriptname)
         {
             var script = db.ContentOfTypePythonScript(scriptname);
-            var model = new PythonModel(db.Copy(), dictionary);
+            var model = new PythonModel(db, dictionary);
             model.FromMorningBatch = FromMorningBatch;
             return ExecutePython(script, model);
         }

--- a/CmsWeb/Controllers/ScriptController.cs
+++ b/CmsWeb/Controllers/ScriptController.cs
@@ -195,9 +195,8 @@ namespace CmsWeb.Controllers
 
                 HostingEnvironment.QueueBackgroundWorkItem(ct =>
                 {
-                    var db = CurrentDatabase.Copy();
                     var qsa = HttpUtility.ParseQueryString(qs ?? "");
-                    var pm = new PythonModel(db);
+                    var pm = new PythonModel(CurrentDatabase);
                     pm.DictionaryAdd("LogFile", logFile);
                     foreach (string key in qsa)
                     {


### PR DESCRIPTION
This will prevent future developers from making the mistake of forgetting to use a Copy of the dbcontext.

I was trying to figure out why the "There is a DataReader already open" error all of a sudden started appearing. 

It turns out it was a side effect of the recently PythonModel constructors passing in the current dbcontext. In some places, the Copy was not being used. The PythonModel should always run on it's own, isolated, dbcontext to prevent side effects from the current dbcontext which may not be finished in the web side.