### PR TITLE
Fix RegEx bug in RunScripts

### DIFF
--- a/CmsData/DbUtil/CreateDatabase.cs
+++ b/CmsData/DbUtil/CreateDatabase.cs
@@ -227,8 +227,7 @@ GO
         {
             using (var cmd = new SqlCommand { Connection = cn, CommandTimeout = 0 })
             {
-                var scripts = Regex.Split(script, "^GO.*$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
-                foreach (var s in scripts)
+                var scripts = Regex.Split(script, "^GO\\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase);                foreach (var s in scripts)
                 {
                     if (s.Trim().HasValue())
                     {


### PR DESCRIPTION
This was crashing on a script that had a parameter on a line by itself that was called goerAmount (or something like that).
RunScripts was interpreting that as a GO command separator.