### PR TITLE
add the user email server side, instead of using the query string

### DIFF
--- a/CmsWeb/Areas/OnlineReg/Models/OnlineReg/Constructor.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineReg/Constructor.cs
@@ -65,6 +65,12 @@ namespace CmsWeb.Areas.OnlineReg.Models
             }
             this.testing = testing == true || DbUtil.Db.Setting("OnlineRegTesting", Util.IsDebug() ? "true" : "false").ToBool();
 
+            // if logged in, use email for logged in user
+            if (AllowAnonymous && !email.HasValue() && Util.UserEmail.HasValue())
+            {
+                email = Util.UserEmail;
+            }
+
             // the email passed in is valid or they did not specify login
             if (AllowAnonymous && (Util.ValidEmail(email) || login != true))
             {

--- a/CmsWeb/Areas/Org/Views/Org/Dialogs.cshtml
+++ b/CmsWeb/Areas/Org/Views/Org/Dialogs.cshtml
@@ -1,5 +1,4 @@
 ﻿@using CmsData
-@using UtilityExtensions
 @model CmsWeb.Areas.Org.Models.OrganizationModel
 @{
     var o = Model.Org;
@@ -16,14 +15,7 @@
           <div>
           Copy the following URL for the public registration link.
               <blockquote>
-                  @if (Model.SettingsRegistrationModel.DisallowAnonymous)
-                  {
-                      <a href="/OnlineReg/@o.OrganizationId?email=@Util.UserEmail" target="blank">@DbUtil.Db.ServerLink("/OnlineReg/" + o.OrganizationId + "?email=" + Util.UserEmail)</a>
-                  }
-                  else
-                  {
-                      <a href="/OnlineReg/@o.OrganizationId" target="blank">@DbUtil.Db.ServerLink("/OnlineReg/" + o.OrganizationId)</a>
-                  }
+                  <a href="/OnlineReg/@o.OrganizationId" target="blank">@DbUtil.Db.ServerLink("/OnlineReg/" + o.OrganizationId)</a>
                   @if (Model.Org.IsOnePageOnlineGiving(DbUtil.Db))
                   {
                       <br /><a href="/OnePageGiving/@o.OrganizationId" target="blank">@DbUtil.Db.ServerLink("/OnePageGiving/" + o.OrganizationId)</a>


### PR DESCRIPTION
a better solution to https://trello.com/c/ecU3lxR6/5604-1-user-selects-org-registration-set-up-nick-wilbur-ingleside-36214 which preserves the url for sharing