### PR TITLE
Removing triple quotation marks in MultipleGateway view.

### DIFF
--- a/CmsWeb/Areas/Setup/Views/Gateway/Index.cshtml
+++ b/CmsWeb/Areas/Setup/Views/Gateway/Index.cshtml
@@ -110,7 +110,7 @@
                                     <label>{{input.GatewayDetailName}}</label>
                                 </div>
                                 <div class="col-md-6">
-                                    <input v-if="input.IsBoolean" type="checkbox" v-model="DetailValue[index]" true-value="'true'" false-value="'false'" />
+                                    <input v-if="input.IsBoolean" type="checkbox" v-model="DetailValue[index]" true-value="true" false-value="false" />
                                     <input required v-else class="form-control" v-model="DetailValue[index]" />
                                 </div>
                             </div>

--- a/TransactionGateway/TransactionGateway.csproj
+++ b/TransactionGateway/TransactionGateway.csproj
@@ -155,16 +155,10 @@
     <Compile Include="Gateways\PushPay\PushPayImport.cs" />
     <Compile Include="Gateways\PushPay\PushPayPayment.cs" />
     <Compile Include="Gateways\PushPay\PushPayRateLimiter.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="obj\Debug\DesignTimeResolveAssemblyReferencesInput.cache" />
-    <None Include="obj\Debug\TransactionGateway.csproj.CoreCompileInputs.cache" />
-    <None Include="obj\Debug\TransactionGateway.csprojAssemblyReference.cache" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
We were storing true and false values as 'true' and 'false' (with quotes marks) in GatewayDetails