### PR TITLE
Fixing mission trip support when org settings has org id fees

### DIFF
--- a/CmsWeb/Areas/OnlineReg/Models/OnlineReg/EnrollAndConfirm.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineReg/EnrollAndConfirm.cs
@@ -31,6 +31,9 @@ namespace CmsWeb.Areas.OnlineReg.Models
                 return EnrollAndConfirmMultipleOrgs();
             }
 
+            if (SupportMissionTrip)
+                List[0].isMissionTripSupporter = true;
+
             if (SupportMissionTrip && TotalAmount() > 0)
             {
                 List[0].Enroll(Transaction, List[0].GetPayLink());

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/OnlineRegPersonModel.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/OnlineRegPersonModel.cs
@@ -135,6 +135,8 @@ namespace CmsWeb.Areas.OnlineReg.Models
         public decimal? MissionTripSupportGoer { get; set; }
         public decimal? MissionTripSupportGeneral { get; set; }
 
+        public bool isMissionTripSupporter { get; set; }
+
         [DisplayFormat(DataFormatString = "{0:N2}", ApplyFormatInEditMode = true)]
         public decimal? Suggestedfee { get; set; }
          

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Transaction.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Transaction.cs
@@ -70,7 +70,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
                 }
             }
             decimal? orgfee = null;
-            if (setting.OrgFees != null)
+            if (setting.OrgFees != null && !isMissionTripSupporter)
             // fee based on being in an organization
             {
                 var q = (from o in setting.OrgFees


### PR DESCRIPTION
This is related to Trello card:
https://trello.com/c/AoKgjVaN/5629-1-parkside-church-member-in-ohio-received-a-receipt-from-ingleside-laurie-admin-ingleside-36473
When an organization has set up org id fees and a specific supporter is a member of one of those orgs the system is taking that fees settled instead of the support amount. 
This is why the first Dan Pillot's attempt to donate to Nathan failed.

I just added a fix to avoid using that org id fees when we are doing a mission trip support.