### PR TITLE
Fix org member type change

### DIFF
--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -378,6 +378,11 @@ AND a.PeopleId = {2}
             var org = db.LoadOrganizationById(organizationId);
             return InsertOrgMembers(db, organizationId, peopleId, memberTypeId, enrollmentDate, inactiveDate, pending, org.OrganizationName, skipTriggerProcessing);
         }
+        public static bool MemberExists(CMSDataContext db, int organizationId, int peopleId)
+        {
+            var org = db.LoadOrganizationById(organizationId);
+            return db.OrganizationMembers.Any(m2 => m2.PeopleId == peopleId && m2.OrganizationId == organizationId);
+        }
         public static OrganizationMember AddOrgMember(CMSDataContext db, int organizationId, int peopleId, int memberTypeId, DateTime enrollmentDate, string name)
         {
             var om = new OrganizationMember

--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -380,7 +380,6 @@ AND a.PeopleId = {2}
         }
         public static bool MemberExists(CMSDataContext db, int organizationId, int peopleId)
         {
-            var org = db.LoadOrganizationById(organizationId);
             return db.OrganizationMembers.Any(m2 => m2.PeopleId == peopleId && m2.OrganizationId == organizationId);
         }
         public static OrganizationMember AddOrgMember(CMSDataContext db, int organizationId, int peopleId, int memberTypeId, DateTime enrollmentDate, string name)

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineReg/EnrollAndConfirm.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineReg/EnrollAndConfirm.cs
@@ -31,6 +31,9 @@ namespace CmsWeb.Areas.OnlineReg.Models
                 return EnrollAndConfirmMultipleOrgs();
             }
 
+            if (SupportMissionTrip)
+                List[0].isMissionTripSupporter = true;
+
             if (SupportMissionTrip && TotalAmount() > 0)
             {
                 List[0].Enroll(Transaction, List[0].GetPayLink());

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Enroll.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Enroll.cs
@@ -483,10 +483,9 @@ namespace CmsWeb.Areas.OnlineReg.Models
         private OrganizationMember GetOrganizationMember(Transaction transaction)
         {
             var membertype = setting.AddAsProspect ? MemberTypeCode.Prospect : MemberTypeCode.Member;
-            if (!OrganizationMember.MemberExists(db, org.OrganizationId, person.PeopleId))
-            {
-                isNewMember = true;
-            }
+
+            isNewMember = !OrganizationMember.MemberExists(db, org.OrganizationId, person.PeopleId);
+
             var om = OrganizationMember.InsertOrgMembers(db, org.OrganizationId, person.PeopleId,
                 membertype, Util.Now, null, false);
             if (om.TranId == null)

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Enroll.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Enroll.cs
@@ -139,6 +139,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
         }
 
         private string cachedPayLink;
+        private bool isNewMember = false;
 
         public string GetPayLink()
         {
@@ -482,6 +483,10 @@ namespace CmsWeb.Areas.OnlineReg.Models
         private OrganizationMember GetOrganizationMember(Transaction transaction)
         {
             var membertype = setting.AddAsProspect ? MemberTypeCode.Prospect : MemberTypeCode.Member;
+            if (!OrganizationMember.MemberExists(db, org.OrganizationId, person.PeopleId))
+            {
+                isNewMember = true;
+            }
             var om = OrganizationMember.InsertOrgMembers(db, org.OrganizationId, person.PeopleId,
                 membertype, Util.Now, null, false);
             if (om.TranId == null)
@@ -497,7 +502,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
 
         private OrganizationMember AddSender(OrganizationMember om)
         {
-            if (!om.IsInGroup("Goer"))
+            if (!om.IsInGroup("Goer") && isNewMember)
             {
                 om.MemberTypeId = MemberTypeCode.InActive;
             }

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/OnlineRegPersonModel.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/OnlineRegPersonModel.cs
@@ -135,6 +135,8 @@ namespace CmsWeb.Areas.OnlineReg.Models
         public decimal? MissionTripSupportGoer { get; set; }
         public decimal? MissionTripSupportGeneral { get; set; }
 
+        public bool isMissionTripSupporter { get; set; }
+
         [DisplayFormat(DataFormatString = "{0:N2}", ApplyFormatInEditMode = true)]
         public decimal? Suggestedfee { get; set; }
          

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Transaction.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineRegPerson/Transaction.cs
@@ -70,7 +70,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
                 }
             }
             decimal? orgfee = null;
-            if (setting.OrgFees != null)
+            if (setting.OrgFees != null && !isMissionTripSupporter)
             // fee based on being in an organization
             {
                 var q = (from o in setting.OrgFees


### PR DESCRIPTION
This is related to https://trello.com/c/AoKgjVaN/5629-1-parkside-church-member-in-ohio-received-a-receipt-from-ingleside-laurie-admin-ingleside-36473
Currently, system change org member type to InActive every time a user does a mission trip donation even if the user is an org member already.
