### PR TITLE
Adding transnational vaultid validation

### DIFF
--- a/CmsData/Finance/TransNationalGateway.cs
+++ b/CmsData/Finance/TransNationalGateway.cs
@@ -65,7 +65,7 @@ namespace CmsData.Finance
 
             if (type == PaymentType.CreditCard)
             {
-                if (paymentInfo.TbnCardVaultId == null) // create new vault.
+                if (paymentInfo.TbnCardVaultId == null || paymentInfo.TbnCardVaultId == 0) // create new vault.
                     paymentInfo.TbnCardVaultId = CreateCreditCardVault(person, paymentInfo, cardNumber, expires);
                 else
                 {
@@ -82,7 +82,7 @@ namespace CmsData.Finance
             }
             else if (type == PaymentType.Ach)
             {
-                if (paymentInfo.TbnBankVaultId == null) // create new vault
+                if (paymentInfo.TbnBankVaultId == null || paymentInfo.TbnBankVaultId == 0) // create new vault
                     paymentInfo.TbnBankVaultId = CreateAchVault(person, paymentInfo, account, routing);
                 else
                 {
@@ -129,6 +129,11 @@ namespace CmsData.Finance
                 });
 
             var response = createCreditCardVaultRequest.Execute();
+            if (string.IsNullOrEmpty(response.VaultId))
+            {
+                throw new Exception(
+                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
+            }
             if (response.ResponseStatus != ResponseStatus.Approved)
                 throw new Exception(
                     $"TransNational failed to create the credit card for people id: {person.PeopleId}, responseCode: {response.ResponseCode}, responseText: {response.ResponseText}");
@@ -220,6 +225,11 @@ namespace CmsData.Finance
                 });
 
             var response = createAchVaultRequest.Execute();
+            if (string.IsNullOrEmpty(response.VaultId))
+            {
+                throw new Exception(
+                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
+            }
             if (response.ResponseStatus != ResponseStatus.Approved)
                 throw new Exception(
                     $"TransNational failed to create the ach account for people id: {person.PeopleId}, responseCode: {response.ResponseCode}, responseText: {response.ResponseText}");

--- a/CmsData/Finance/TransNationalGateway.cs
+++ b/CmsData/Finance/TransNationalGateway.cs
@@ -65,36 +65,11 @@ namespace CmsData.Finance
 
             if (type == PaymentType.CreditCard)
             {
-                if (paymentInfo.TbnCardVaultId == null || paymentInfo.TbnCardVaultId == 0) // create new vault.
-                    paymentInfo.TbnCardVaultId = CreateCreditCardVault(person, paymentInfo, cardNumber, expires);
-                else
-                {
-                    // update existing vault.
-                    // check for updating the entire card or only expiration.
-                    if (!cardNumber.StartsWith("X"))
-                        UpdateCreditCardVault(person, paymentInfo, cardNumber, expires);
-                    else
-                        UpdateCreditCardVault(person, paymentInfo, expires);
-                }
-
-                paymentInfo.MaskedCard = Util.MaskCC(cardNumber);
-                paymentInfo.Expires = expires;
+                StoreCreditCardVault(paymentInfo, person, paymentInfo, cardNumber, expires);
             }
             else if (type == PaymentType.Ach)
             {
-                if (paymentInfo.TbnBankVaultId == null || paymentInfo.TbnBankVaultId == 0) // create new vault
-                    paymentInfo.TbnBankVaultId = CreateAchVault(person, paymentInfo, account, routing);
-                else
-                {
-                    // we can only update the ach account if there is a full account number.
-                    if (!account.StartsWith("X"))
-                        UpdateAchVault(person, paymentInfo, account, routing);
-                    else
-                        UpdateAchVault(person, paymentInfo);
-                }
-
-                paymentInfo.MaskedAccount = Util.MaskAccount(account);
-                paymentInfo.Routing = Util.Mask(new StringBuilder(routing), 2);
+                StoreAchVault(paymentInfo, person, account, routing);
             }
             else
                 throw new ArgumentException($"Type {type} not supported", nameof(type));
@@ -104,6 +79,40 @@ namespace CmsData.Finance
             else
                 paymentInfo.PreferredPaymentType = type;
             db.SubmitChanges();
+        }
+
+        private void StoreAchVault(PaymentInfo paymentInfo, Person person, string account, string routing)
+        {
+            if (paymentInfo.TbnBankVaultId == null) // create new vault
+                paymentInfo.TbnBankVaultId = CreateAchVault(person, paymentInfo, account, routing);
+            else
+            {
+                // we can only update the ach account if there is a full account number.
+                if (!account.StartsWith("X"))
+                    UpdateAchVault(person, paymentInfo, account, routing);
+                else
+                    UpdateAchVault(person, paymentInfo);
+            }
+            paymentInfo.MaskedAccount = Util.MaskAccount(account);
+            paymentInfo.Routing = Util.Mask(new StringBuilder(routing), 2);
+        }
+
+        private void StoreCreditCardVault(PaymentInfo paymentInfo, Person person, PaymentInfo paymentInfo2, string cardNumber, string expires)
+        {            
+            if (paymentInfo.TbnCardVaultId == null) // create new vault.
+                paymentInfo.TbnCardVaultId = CreateCreditCardVault(person, paymentInfo, cardNumber, expires);
+            else
+            {
+                // update existing vault.
+                // check for updating the entire card or only expiration.
+                if (!cardNumber.StartsWith("X"))
+                    UpdateCreditCardVault(person, paymentInfo, cardNumber, expires);
+                else
+                    UpdateCreditCardVault(person, paymentInfo, expires);
+            }
+
+            paymentInfo.MaskedCard = Util.MaskCC(cardNumber);
+            paymentInfo.Expires = expires;
         }
 
         private int CreateCreditCardVault(Person person, PaymentInfo paymentInfo, string cardNumber, string expiration)
@@ -129,14 +138,12 @@ namespace CmsData.Finance
                 });
 
             var response = createCreditCardVaultRequest.Execute();
-            if (string.IsNullOrEmpty(response.VaultId))
-            {
-                throw new Exception(
-                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
-            }
             if (response.ResponseStatus != ResponseStatus.Approved)
                 throw new Exception(
                     $"TransNational failed to create the credit card for people id: {person.PeopleId}, responseCode: {response.ResponseCode}, responseText: {response.ResponseText}");
+            if (string.IsNullOrEmpty(response.VaultId))
+                throw new Exception(
+                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
 
             return response.VaultId.ToInt();
         }
@@ -225,14 +232,12 @@ namespace CmsData.Finance
                 });
 
             var response = createAchVaultRequest.Execute();
-            if (string.IsNullOrEmpty(response.VaultId))
-            {
-                throw new Exception(
-                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
-            }
             if (response.ResponseStatus != ResponseStatus.Approved)
                 throw new Exception(
                     $"TransNational failed to create the ach account for people id: {person.PeopleId}, responseCode: {response.ResponseCode}, responseText: {response.ResponseText}");
+            if (string.IsNullOrEmpty(response.VaultId))
+                throw new Exception(
+                    $"TransNational is not returning VaultId. Please contact the system administrator to activate this feature.");
 
             return response.VaultId.ToInt();
         }

--- a/CmsWeb/Areas/OnlineReg/Models/OnlineReg/PaymentForm.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/OnlineReg/PaymentForm.cs
@@ -573,6 +573,14 @@ namespace CmsWeb.Areas.OnlineReg.Models
 
             var gateway = CurrentDatabase.Gateway(testing, null, ProcessType);
 
+            //Validates if stored payment info is correct
+            ValidatesPaymentInfo(modelState, peopleid, Type, gateway);
+
+            if (!modelState.IsValid)
+            {
+                return;
+            }
+
             // we need to perform a $1 auth if this is a brand new credit card that we are going to store it in the vault.
             // otherwise we skip doing an auth just call store in vault just like normal.
             VerifyCardWithAuth(modelState, gateway, peopleid);
@@ -586,6 +594,47 @@ namespace CmsWeb.Areas.OnlineReg.Models
             gateway.StoreInVault(peopleid, Type, CreditCard,
                 DbUtil.NormalizeExpires(Expires).ToString2("MMyy"), CVV, Routing, Account,
                 IsGiving.GetValueOrDefault());
+        }
+
+        private void ValidatesPaymentInfo(ModelStateDictionary modelState, int peopleid, string type, IGateway gateway)
+        {
+            Person person = CurrentDatabase.LoadPersonById(peopleid);
+            PaymentInfo paymentInfo = person.PaymentInfo(gateway.GatewayAccountId);
+            if (paymentInfo != null)
+            {
+                switch (gateway.GatewayType)
+                {
+                    case "TransNational":
+                        ValidatesTransNationalInfo(modelState, paymentInfo);
+                    break;
+                }
+            }
+        }
+
+        private void ValidatesTransNationalInfo(ModelStateDictionary modelState, PaymentInfo paymentInfo)
+        {
+            if (Type == PaymentType.CreditCard && paymentInfo.TbnCardVaultId == 0)
+            {
+                paymentInfo.MaskedCard = null;
+                paymentInfo.Expires = null;
+                paymentInfo.TbnCardVaultId = null;
+                CurrentDatabase.SubmitChanges();
+                modelState.Clear();
+                CreditCard = string.Empty;
+                Expires = string.Empty;
+                modelState.AddModelError("CreditCard", "Please insert card number.");
+            }
+            else if (Type == PaymentType.Ach && paymentInfo.TbnBankVaultId == 0)
+            {
+                paymentInfo.MaskedAccount = null;
+                paymentInfo.Routing = null;
+                paymentInfo.TbnBankVaultId = null;
+                CurrentDatabase.SubmitChanges();
+                modelState.Clear();
+                Routing = string.Empty;
+                Account = string.Empty;
+                modelState.AddModelError("Routing", "Please insert routing.");
+            }
         }
 
         /// Perform a $1 authorization... the amount is randomized because some gateways will reject identical, subsequent amounts
@@ -698,7 +747,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
 
             CurrentDatabase.SubmitChanges();
             return ti;
-        }        
+        }
 
         private TransactionResponse PayWithCreditCard(IGateway gateway, int? peopleId, Transaction transaction)
         {


### PR DESCRIPTION
https://trello.com/c/UDyc2avt/5597-bug-getting-error-when-updating-giving-amount-and-changing-from-a-bank-account-to-a-credit-card

Validates when TransNational is not returning the vault id. In case we already have 0 stored we request a new vault id.