### PR TITLE
fix sort bundles by id and status functionality

### DIFF
--- a/CmsWeb/Areas/Finance/Models/BundlesModel.cs
+++ b/CmsWeb/Areas/Finance/Models/BundlesModel.cs
@@ -103,9 +103,13 @@ namespace CmsWeb.Areas.Finance.Models
                             select b;
                         break;
                     case "Id":
+                        q = from b in q
+                            orderby b.BundleHeaderId
+                            select b;
+                        break;
                     case "Status":
                         q = from b in q
-                            orderby b.Status descending, b.BundleHeaderId descending
+                            orderby b.Status, b.BundleHeaderId descending
                             select b;
                         break;
                 }
@@ -145,6 +149,10 @@ namespace CmsWeb.Areas.Finance.Models
                             select b;
                         break;
                     case "Id":
+                        q = from b in q
+                            orderby b.BundleHeaderId descending
+                            select b;
+                        break;
                     case "Status":
                         q = from b in q
                             orderby b.Status descending, b.BundleHeaderId descending


### PR DESCRIPTION
https://trello.com/c/SQ0DoTiz/5680-bug-unable-to-sort-by-status-column-on-the-contribution-bundles-page