### PR TITLE
Log Changes from Update Data by Tag/Query

### DIFF
--- a/CmsData/API/PythonModel/Person.cs
+++ b/CmsData/API/PythonModel/Person.cs
@@ -207,6 +207,7 @@ namespace CmsData
             {
                 var pp = db2.LoadPersonById(p.PeopleId);
                 pp.UpdateValue(field, value);
+                p.LogChanges(db2);
                 db2.SubmitChanges();
             }
         }

--- a/CmsWeb/Areas/Manage/Models/UpdateFieldsModel.cs
+++ b/CmsWeb/Areas/Manage/Models/UpdateFieldsModel.cs
@@ -319,7 +319,6 @@ namespace CmsWeb.Models
                     return;
                 }
 
-
                 if (psb.Count > 0)
                 {
                     var c = new ChangeLog

--- a/CmsWeb/Areas/Manage/Models/UpdateFieldsModel.cs
+++ b/CmsWeb/Areas/Manage/Models/UpdateFieldsModel.cs
@@ -172,9 +172,11 @@ namespace CmsWeb.Models
                         DoBackgroundChecks(p);
                         break;
                     case "Baptism Status":
+                        TrackChange(Field, p.BaptismStatusId, NewValue);
                         p.BaptismStatusId = NewValue.ToInt2();
                         break;
                     case "Baptism Type":
+                        TrackChange(Field, p.BaptismTypeId, NewValue);
                         p.BaptismTypeId = NewValue.ToInt2();
                         break;
                     case "Baptism Date":
@@ -182,67 +184,85 @@ namespace CmsWeb.Models
                         p.LogChanges(DbUtil.Db, Util.UserPeopleId ?? 1);
                         break;
                     case "Campus":
+                        TrackChange(Field, p.CampusId, NewValue);
                         p.CampusId = NewValue.ToInt2();
                         break;
                     case "Deceased Date":
                         if (DateValid())
                         {
+                            TrackChange(Field, p.DeceasedDate, NewValue);
                             p.DeceasedDate = NewValue.ToDate();
                         }
 
                         break;
                     case "Decision Type":
+                        TrackChange(Field, p.DecisionTypeId, NewValue);
                         p.DecisionTypeId = NewValue.ToInt2();
                         break;
                     case "Do Not Call":
+                        TrackChange(Field, p.DoNotCallFlag, NewValue);
                         p.DoNotCallFlag = NewValue.ToBool();
                         break;
                     case "Do Not Mail":
+                        TrackChange(Field, p.DoNotMailFlag, NewValue);
                         p.DoNotMailFlag = NewValue.ToBool();
                         break;
                     case "Drop All Enrollments":
                         p.DropMemberships(DbUtil.Db);
                         break;
                     case "Drop Date":
+                        TrackChange(Field, p.DropDate, NewValue);
                         p.DropDate = NewValue.ToDate();
                         break;
                     case "Drop Type":
+                        TrackChange(Field, p.DropCodeId, NewValue);
                         p.DropCodeId = NewValue.ToInt();
                         break;
                     case "Entry Point":
+                        TrackChange(Field, p.EntryPointId, NewValue);
                         p.EntryPointId = NewValue.ToInt2();
                         break;
                     case "Employer":
+                        TrackChange(Field, p.EmployerOther, NewValue);
                         p.EmployerOther = NewValue;
                         break;
                     case "Envelope Options":
+                        TrackChange(Field, p.EnvelopeOptionsId, NewValue);
                         p.EnvelopeOptionsId = NewValue.ToInt2();
                         break;
                     case "Family Position":
+                        TrackChange(Field, p.PositionInFamilyId, NewValue);
                         p.PositionInFamilyId = NewValue.ToInt();
                         break;
                     case "Gender":
+                        TrackChange(Field, p.GenderId, NewValue);
                         p.GenderId = NewValue.ToInt();
                         break;
                     case "Grade":
                         DoGrade(p);
                         break;
                     case "Join Type":
+                        TrackChange(Field, p.JoinCodeId, NewValue);
                         p.JoinCodeId = NewValue.ToInt();
                         break;
                     case "Marital Status":
+                        TrackChange(Field, p.MaritalStatusId, NewValue);
                         p.MaritalStatusId = NewValue.ToInt();
                         break;
                     case "Member Status":
+                        TrackChange(Field, p.MemberStatusId, NewValue);
                         p.MemberStatusId = NewValue.ToInt();
                         break;
                     case "Occupation":
+                        TrackChange(Field, p.OccupationOther, NewValue);
                         p.OccupationOther = NewValue;
                         break;
                     case "New Member Class":
+                        TrackChange(Field, p.NewMemberClassStatusId, NewValue);
                         p.NewMemberClassStatusId = NewValue.ToInt2();
                         break;
                     case "ReceiveSMS":
+                        TrackChange(Field, p.ReceiveSMS, NewValue);
                         p.ReceiveSMS = NewValue.ToBool();
                         break;
                     case "Remove Address":
@@ -271,18 +291,23 @@ namespace CmsWeb.Models
                         }
                         break;
                     case "School":
+                        TrackChange(Field, p.SchoolOther, NewValue);
                         p.SchoolOther = NewValue;
                         break;
                     case "Statement Options":
+                        TrackChange(Field, p.ContributionOptionsId, NewValue);
                         p.ContributionOptionsId = NewValue.ToInt2();
                         break;
                     case "Electronic Statement":
+                        TrackChange(Field, p.ElectronicStatement, NewValue);
                         p.ElectronicStatement = NewValue.ToBool2();
                         break;
                     case "Title":
+                        TrackChange(Field, p.TitleCode, NewValue);
                         p.TitleCode = NewValue;
                         break;
                     case "New Member Class Date":
+                        TrackChange(Field, p.NewMemberClassDate, NewValue);
                         p.NewMemberClassDate = NewValue.ToDate();
                         break;
                     case "New OrgLeadersOnly":
@@ -294,8 +319,30 @@ namespace CmsWeb.Models
                     return;
                 }
 
+
+                if (psb.Count > 0)
+                {
+                    var c = new ChangeLog
+                    {
+                        UserPeopleId = Util.UserPeopleId.GetValueOrDefault(),
+                        PeopleId = p.PeopleId,
+                        Field = Field,
+                        Created = Util.Now
+                    };
+                    DbUtil.Db.ChangeLogs.InsertOnSubmit(c);
+                    c.ChangeDetails.AddRange(psb);
+                }
+
                 DbUtil.Db.SubmitChanges();
+                psb = new List<ChangeDetail>();
             }
+        }
+
+        private List<ChangeDetail> psb = new List<ChangeDetail>();
+
+        private void TrackChange(string field, object oldValue, object newValue)
+        {
+            psb.Add(new ChangeDetail(field, oldValue, newValue));
         }
 
         private void DoGrade(Person p)

--- a/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
@@ -32,16 +32,7 @@
             }
           </td>
           <td><a href="/LastActivity?orgid=@a.OrgId">@a.OrgName</a></td>
-            <td>
-                @if (a.UserId.IsNull() && a.Activity.Contains("Script"))
-                {
-                    <span>Admin Script</span>
-                }
-                else
-                {
-                    <a href="/LastActivity?peopleid=@a.PeopleId">@a.PersonName</a>
-                }
-            </td>
+          <td><a href="/LastActivity?peopleid=@a.PeopleId">@a.PersonName</a></td>
         </tr>
       }
     </tbody>

--- a/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
@@ -32,7 +32,16 @@
             }
           </td>
           <td><a href="/LastActivity?orgid=@a.OrgId">@a.OrgName</a></td>
-          <td><a href="/LastActivity?peopleid=@a.PeopleId">@a.PersonName</a></td>
+            <td>
+                @if (a.UserId.IsNull() && a.Activity.Contains("Script"))
+                {
+                    <span>Admin Scripts</span>
+                }
+                else
+                {
+                    <a href="/LastActivity?peopleid=@a.PeopleId">@a.PersonName</a>
+                }
+            </td>
         </tr>
       }
     </tbody>

--- a/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
+++ b/CmsWeb/Areas/Manage/Views/Activity/Results.cshtml
@@ -35,7 +35,7 @@
             <td>
                 @if (a.UserId.IsNull() && a.Activity.Contains("Script"))
                 {
-                    <span>Admin Scripts</span>
+                    <span>Admin Script</span>
                 }
                 else
                 {

--- a/CmsWeb/Areas/People/Models/Person/Changes/ChangesModel.cs
+++ b/CmsWeb/Areas/People/Models/Person/Changes/ChangesModel.cs
@@ -65,7 +65,7 @@ namespace CmsWeb.Areas.People.Models
                       let userp = DbUtil.Db.People.SingleOrDefault(u => u.PeopleId == c.UserPeopleId)
                       select new ChangeLogInfo()
                       {
-                          User = userp.Name,
+                          User = c.UserPeopleId == 0 ? "Admin Script" : userp.Name,
                           FieldSet = c.Section,
                           Time = c.Created,
                           Field = c.Field,


### PR DESCRIPTION
Add `TrackChanges` method to log changes from Update Data by Tag/Query page, following [convention in AddressInfo.cs](https://github.com/bvcms/bvcms/blob/develop/CmsWeb/Areas/People/Models/AddressInfo.cs#L304).

Additionally, add a call to `LogChanges` for Python Scripts in one additional place to match [UpdateCampus](https://github.com/bvcms/bvcms/blob/develop/CmsData/API/PythonModel/Person.cs#L198) and [UpdateMemberStatus](https://github.com/bvcms/bvcms/blob/develop/CmsData/API/PythonModel/Person.cs#L228).

Lastly, mask changes from `PythonModel` as "Admin Scripts" under Profile > System > Changes, which we infer from [the null coalesce to `0` in Person Extensions](https://github.com/bvcms/bvcms/blob/develop/CmsData/Extensions/Person.cs#L1410).