### PR TITLE
Fix MissionTripEmail error page issue

### DIFF
--- a/CmsWeb/Areas/Org/Controllers/MissionTripEmailController.cs
+++ b/CmsWeb/Areas/Org/Controllers/MissionTripEmailController.cs
@@ -2,14 +2,19 @@ using System.Linq;
 using System.Web.Mvc;
 using CmsData;
 using CmsWeb.Areas.Org.Models;
+using CmsWeb.Lifecycle;
 using Newtonsoft.Json;
 using UtilityExtensions;
 
 namespace CmsWeb.Areas.Org.Controllers
 {
     [RouteArea("Org", AreaPrefix = "")]
-    public class MissionTripEmailController : Controller
+    public class MissionTripEmailController : CmsStaffController
     {
+        public MissionTripEmailController(IRequestManager requestManager) : base(requestManager)
+        {
+        }
+
         [HttpGet, Route("MissionTripEmail2/{oid}/{pid}")]
         public ActionResult Index(int oid, int pid)
         {


### PR DESCRIPTION
ViewData.CurrentDatabase was null
Change base controller to CmsStaffController
Add Constructor method passing requestManager to base
Related with this card
https://trello.com/c/jpvTEH4N/5806-mission-trip-email-supporters-button-give-a-red-page-error-object-not-set-to-an-instance-of-an-object