### PR TITLE
Meeting Attendance Report Fix

### DIFF
--- a/CmsWeb/Areas/Reports/Models/Attendance/MeetingAttendanceModel.cs
+++ b/CmsWeb/Areas/Reports/Models/Attendance/MeetingAttendanceModel.cs
@@ -79,7 +79,7 @@ namespace CmsWeb.Areas.Reports.Models.Attendance
             if (weeks.Count > 0 && weeks[0] >= StartDt) {
                 StartDt = weeks[0];
             }
-            if (weeks[weeks.Count - 1] != EndDt)
+            if (weeks.Count > 0 && weeks[weeks.Count - 1] != EndDt)
             {
                 weeks.Add(EndDt);
             }


### PR DESCRIPTION
Validates if week property is empty
https://trello.com/c/3HHeQwDT/5865-bug-attendance-by-meeting-type-report-returning-error-in-fielder-database