### PR TITLE
Contribution Search Fix

### DIFF
--- a/CmsWeb/Areas/Finance/Controllers/ContributionsController.cs
+++ b/CmsWeb/Areas/Finance/Controllers/ContributionsController.cs
@@ -82,8 +82,9 @@ namespace CmsWeb.Areas.Finance.Controllers
             return View(m);
         }
         [HttpPost]
-        public ActionResult Results(ContributionSearchModel m)
+        public ActionResult Results(ContributionSearchInfo SearchInfo)
         {
+            ContributionSearchModel m = new ContributionSearchModel(CurrentDatabase, SearchInfo);
             var ret = m.CheckConversion();
             if (ret.HasValue())
             {


### PR DESCRIPTION
Taking SearchInfo as parameter instead of ContributionSearchModel
https://trello.com/c/JufKUT54/5957-parameters-on-contribution-search-page-not-working-2-problem-exporting-fund-details-larry-reid-stonyrunfriends-38864