### PR TITLE
Better Python debugging and installation

### DIFF
--- a/CmsData/API/PythonModel/DebugScriptsHelper.cs
+++ b/CmsData/API/PythonModel/DebugScriptsHelper.cs
@@ -12,6 +12,48 @@ namespace CmsData
     public class DebugScriptsHelper
     {
 #if DEBUG
+        /// <summary>
+        /// LocateLocalFileInPath
+        /// 
+        /// This method facilitates developing and debugging Python Projects involving multiple file types.
+        /// It is intended to be run within Visual Studio against a local database.
+        /// However, while not recommended, it will also work with a connectionstring to a production database.
+        /// It is designed to allow you to edit every file locally with your favorite code editor.
+        /// I prefer Visual Studio Code rather than mixing in with the normal Visual Studio.
+        /// To debug a Python script:
+        ///     You must uncheck the 'Enable Just My Code' setting
+        ///         in Tools>Options>Debugging/General area (requires restart I think).
+        ///     You must open the file being debugged in the Visual Studio running bvcms.
+        ///         You do not need to copy the file to the bvcms project however.
+        ///         Just open it from Visual Studio.
+        ///         This way, every change made in Visual Studio Code,
+        ///         will automatically ask to propagate changes to the file open in Visual Studio.
+        ///     You must be in Debug mode.
+        ///     You will need to add two settings in your AppSettings:
+        ///         <add key="LocalScriptsPath" value="c:/dev/MyProject"/>
+        ///         <add key="LocalScriptsContentKeyword" value="MyProject"/>
+        ///         MyProject would be the name of your project, which should not conflict with any other project
+        ///         LocalScriptsPath is the place you add all of your project files in any Directory structure you want.
+        ///         LocalScriptsContentKey is the keyword used in Special Content to filter just your project.
+        ///         I use a secrets.config file so as to not accidently commit that setting to the GitHub repo via the Web.Config file.
+        /// Having these requirements satisfied, you can set breakpoints and examine variables.
+        /// Unfortunately, global variables outside of a function def are not able to be inspected.
+        /// To get around this, I pass any global variable I need to inspect as a function argument and inspect the parameter there.
+        /// Of course, you can always use Python's print statement.
+        ///
+        /// LocalLocalFileInPath serves two purposes:
+        ///     1)  It finds the full path of the file and writes the file's text
+        ///         into the appropriate Special Content folder
+        ///         using the extensionless name of the file with the keyword attached for filtering.
+        ///     2)  Additionally, if the file is a Python script,
+        ///         it will allow the file run the file in debug mode assuming all of the above requirements are set.
+        ///
+        /// Basically, this function works from three locations:
+        ///     CmsWeb/Models/PythonScriptModel.cs -- FetchScript(name) method
+        ///     CmsWeb/Models/SqlScriptModel.cs -- FetchScript(name) method
+        ///     CMSData/API/PythonModel/PythonModel.Misc.cs -- Content(name) method
+        /// 
+        /// </summary>
         public static string LocateLocalFileInPath(CMSDataContext db, string name, string ext)
         {
             if (string.IsNullOrEmpty(name))
@@ -59,23 +101,20 @@ namespace CmsData
         {
             var files = dirinfo.GetFiles($"*{ext}");
 
-            if (files != null)
+            foreach (var fi in files)
             {
-                foreach (var fi in files)
-                {
-                    var fn = Path.GetFileNameWithoutExtension(fi.Name);
-                    if (fn.EndsWith(".text"))
-                        fn = Path.GetFileNameWithoutExtension(fn);
-                    if (fn.EndsWith(".view"))
-                        fn = Path.GetFileNameWithoutExtension(fn);
-                    list[fn] = fi.FullName;
-                }
-                foreach (var subdir in dirinfo.GetDirectories())
-                {
-                    if (subdir.Name.StartsWith("."))
-                        continue;
-                    WalkTree(subdir, ext, list);
-                }
+                var fn = Path.GetFileNameWithoutExtension(fi.Name);
+                if (fn.EndsWith(".text"))
+                    fn = Path.GetFileNameWithoutExtension(fn);
+                if (fn.EndsWith(".view"))
+                    fn = Path.GetFileNameWithoutExtension(fn);
+                list[fn] = fi.FullName;
+            }
+            foreach (var subdir in dirinfo.GetDirectories())
+            {
+                if (subdir.Name.StartsWith("."))
+                    continue;
+                WalkTree(subdir, ext, list);
             }
         }
 #endif

--- a/CmsData/API/PythonModel/DebugScriptsHelper.cs
+++ b/CmsData/API/PythonModel/DebugScriptsHelper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Configuration;
+using UtilityExtensions;
+
+namespace CmsData
+{
+    public class DebugScriptsHelper
+    {
+#if DEBUG
+        public static string LocateLocalFileInPath(CMSDataContext db, string name, string ext)
+        {
+            if (string.IsNullOrEmpty(name))
+                return null;
+            var path = WebConfigurationManager.AppSettings["LocalScriptsPath"];
+            var keyword = WebConfigurationManager.AppSettings["LocalScriptsContentKeyword"];
+            if (!path.HasValue())
+                return null;
+            var dirinfo = new DirectoryInfo(path);
+            var list = new Dictionary<string, string>();
+            WalkTree(dirinfo, ext, list);
+            if (list.ContainsKey(name))
+            {
+                var fullpath = list[name];
+                var script = File.ReadAllText(fullpath);
+
+                var nam = Path.GetFileNameWithoutExtension(fullpath);
+                ext = Path.GetExtension(fullpath);
+                if (fullpath.EndsWith(".text.html"))
+                {
+                    ext = Path.GetExtension(nam);
+                    nam = Path.GetFileNameWithoutExtension(nam);
+                }
+                switch (ext)
+                {
+                    case ".py":
+                        db.WriteContentPython(nam, script, keyword);
+                        break;
+                    case ".sql":
+                        db.WriteContentSql(nam, script, keyword);
+                        break;
+                    case ".text":
+                    case ".json":
+                        db.WriteContentText(nam, script, keyword);
+                        break;
+                    case ".html":
+                        db.WriteContentHtml(nam, script, keyword);
+                        break;
+                }
+                return fullpath;
+            }
+            return null;
+        }
+        private static void WalkTree(DirectoryInfo dirinfo, string ext, Dictionary<string, string> list)
+        {
+            var files = dirinfo.GetFiles($"*{ext}");
+
+            if (files != null)
+            {
+                foreach (var fi in files)
+                {
+                    var fn = Path.GetFileNameWithoutExtension(fi.Name);
+                    if (fn.EndsWith(".text"))
+                        fn = Path.GetFileNameWithoutExtension(fn);
+                    if (fn.EndsWith(".view"))
+                        fn = Path.GetFileNameWithoutExtension(fn);
+                    list[fn] = fi.FullName;
+                }
+                foreach (var subdir in dirinfo.GetDirectories())
+                {
+                    if (subdir.Name.StartsWith("."))
+                        continue;
+                    WalkTree(subdir, ext, list);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/CmsData/API/PythonModel/PythonModel.Misc.cs
+++ b/CmsData/API/PythonModel/PythonModel.Misc.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.Caching;
+using System.Web.Configuration;
 using UtilityExtensions;
 using Method = RestSharp.Method;
 
@@ -72,56 +73,12 @@ namespace CmsData
             }
         }
 
-        public string Content(string name, string keyword = null)
+        public string Content(string name)
         {
+#if DEBUG
+            DebugScriptsHelper.LocateLocalFileInPath(db, name, ".text");
+#endif
             var c = db.Content(name);
-            if (IsDebug && c == null)
-            {
-                var txt = ReadFile(name);
-                if (!txt.HasValue())
-                {
-                    return txt;
-                }
-
-                var nam = Path.GetFileNameWithoutExtension(name);
-                var ext = Path.GetExtension(name);
-                int typ = ContentTypeCode.TypeText;
-                if (name.EndsWith(".text.html"))
-                {
-                    ext = Path.GetExtension(nam);
-                    nam = Path.GetFileNameWithoutExtension(nam);
-                }
-                switch (ext)
-                {
-                    case ".sql":
-                        typ = ContentTypeCode.TypeSqlScript;
-                        break;
-                    case ".text":
-                        typ = ContentTypeCode.TypeText;
-                        break;
-                    case ".html":
-                        typ = ContentTypeCode.TypeHtml;
-                        break;
-                }
-                c = db.Content(nam, typ);
-                if (c == null)
-                {
-                    c = new Content
-                    {
-                        Name = nam,
-                        TypeID = typ
-                    };
-                    db.Contents.InsertOnSubmit(c);
-                }
-                c.Body = txt;
-                if (keyword.HasValue())
-                {
-                    c.SetKeyWords(db, new[] { keyword });
-                }
-
-                db.SubmitChanges();
-            }
-
             return c.Body;
         }
 
@@ -585,6 +542,11 @@ DELETE dbo.Tag WHERE TypeId = 101 AND Name LIKE @namelike
         public void WriteContentText(string name, string text, string keyword = null)
         {
             db.WriteContentText(name, text, keyword);
+        }
+
+        public void WriteContentHtml(string name, string text, string keyword = null)
+        {
+            db.WriteContentHtml(name, text, keyword);
         }
 
         public int TagLastQuery(string defaultcode)

--- a/CmsData/CmsData.csproj
+++ b/CmsData/CmsData.csproj
@@ -326,6 +326,7 @@
     <Compile Include="API\ApiSessionResult.cs" />
     <Compile Include="API\ApiSessionStatus.cs" />
     <Compile Include="API\CreateExcel.cs" />
+    <Compile Include="API\PythonModel\DebugScriptsHelper.cs" />
     <Compile Include="API\PythonModel\PythonModel.Docusign.cs" />
     <Compile Include="API\PythonModel\PythonModel.DynamicData.cs" />
     <Compile Include="API\PythonModel\PythonModel.Deprecated.cs" />

--- a/CmsData/DbUtil/Context.cs
+++ b/CmsData/DbUtil/Context.cs
@@ -1721,6 +1721,23 @@ This search uses multiple steps which cannot be duplicated in a single query.
             c.Body = text;
             SubmitChanges();
         }
+        public void WriteContentHtml(string name, string text, string keyword = null)
+        {
+            var c = Content(name, ContentTypeCode.TypeHtml);
+            if (c == null)
+            {
+                c = new Content()
+                {
+                    Name = name,
+                    TypeID = ContentTypeCode.TypeHtml
+                };
+                Contents.InsertOnSubmit(c);
+            }
+            if(keyword.HasValue())
+                c.SetKeyWords(this, new [] {keyword});
+            c.Body = text;
+            SubmitChanges();
+        }
         public void SetNoLock()
         {
             //ExecuteCommand("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");

--- a/CmsWeb/CMSWeb.csproj
+++ b/CmsWeb/CMSWeb.csproj
@@ -1704,6 +1704,7 @@
     <Content Include="Content\touchpoint\lib\select2\css\select2x2.png" />
     <Content Include="Content\touchpoint\lib\select2\js\select2.min.js" />
     <Content Include="Content\touchpoint\lib\twitter-typeahead\js\typeahead.js" />
+    <Content Include="Content\InstallPyScriptProject.py" />
     <Content Include="Content\xml.xsl" />
     <Content Include="Content\images\brokencode.jpg" />
     <Content Include="Content\images\sgfunknown.jpg" />

--- a/CmsWeb/Content/InstallPyScriptProject.py
+++ b/CmsWeb/Content/InstallPyScriptProject.py
@@ -1,0 +1,66 @@
+import re
+
+def Get():
+    model.Form = '''
+<!DOCTYPE html>
+<form enctype="multipart/form-data" action="InstallPyScriptProject" method=post>
+<p><label for=zip>File: <input type=file name=zip>
+<p><input type=submit>
+</form>
+'''
+
+def Post(data):
+    zipfile = data['zip']
+    keyword = zipfile["keyword"]
+    Install = None
+    print('<pre>')
+    keys = list(zipfile.Keys())
+    keys.sort()
+    for key in keys:
+        text = zipfile[key]
+        if key == "keyword":
+            continue
+        if key == "Install.py":
+            Install = text
+            continue
+
+        if key.endswith(".view.sql"):
+            key = re.search("\d*(.*)\.view\.sql", key).group(1)
+            model.CreateCustomView(key, text)
+            print("%s installed in custom.Views" % key)
+
+        elif key.endswith(".text.html"):
+            key = re.search("(.*)\.text\.html", key).group(1)
+            model.WriteContentText(key, text, keyword)
+            print("%s installed in Text Content with Keyword %s" % (key, keyword))
+
+        elif key.endswith(".sql"):
+            key = re.search("(.*)\.sql", key).group(1)
+            model.WriteContentSql(key, text, keyword)
+            print("%s installed in Sql Scripts" % key)
+
+        elif key.endswith(".py"):
+            key = re.search("(.*)\.py", key).group(1)
+            model.WriteContentPython(key, text, keyword)
+            print("%s installed in Python Scripts with Keyword %s" % (key, keyword))
+
+        elif key.endswith(".json"):
+            key = re.search("(.*).json", key).group(1)
+            model.WriteContentText(key, text, keyword)
+            print("%s installed in Text Content with Keyword %s" % (key, keyword))
+
+        elif key.endswith(".html"):
+            key = re.search("(.*)\.html", key).group(1)
+            model.WriteContentHtml(key, text, keyword)
+            print("%s installed in Html Content with Keyword %s" % (key, keyword))
+
+    if Install:
+        model.RunScript(Install)
+        print("Install.py run but not added to Content")
+
+    print('</pre>')
+
+if model.HttpMethod == 'get':
+    Get()
+elif model.HttpMethod == 'post':
+    Post(Data)

--- a/CmsWeb/Controllers/ScriptController.cs
+++ b/CmsWeb/Controllers/ScriptController.cs
@@ -224,6 +224,53 @@ namespace CmsWeb.Controllers
                 return Content($@"<div class='alert alert-danger' style='font-family: monospace; white-space: pre;'>{ex.Message}</div></div>");
             }
         }
-    }
 
+        /// <summary>
+        /// InstallPyScriptProject
+        /// 
+        /// This method will allow an Admin to install a Python project
+        /// with many files of different types stored in a zip file.
+        /// 
+        /// The files can be any of the following types:
+        ///   *.view.sql -- installs in the database as a custom view.
+        ///     The files should be numbered with leading digits so as to install in that order.
+        ///     The ordering is important if any view depends on another view.
+        ///     If there are no dependancies, then the leading digits are not necessary.
+        ///     The name of the view will be the name of the file excluding the leading digits and the extensions.
+        ///   *.text.html -- this is an html file stored as a text file (easier to edit that way)
+        ///   *.sql -- A SQL report
+        ///   *.py -- A python script
+        ///   *.json -- stored as text, but can be parsed and used in a view
+        ///   *.html -- stored as html and uses the html editor
+        ///   Install.py -- This is optional and is not stored in the database.
+        ///     It runs once after all files/views are installed and is used when custom initialization is required.
+        /// 
+        /// It is required that all files have unique names when the extension is removed,
+        /// that is, you cannot have MyProjectRunReport.py and MyProjectRunReport.sql.
+        ///
+        /// Also, it is required to prefix every file and view with a unique name.
+        /// This allows the files to be grouped together and not clobber files of the same name during installation.
+        ///
+        /// Any folder heirarchy is ignored.
+        ///
+        /// All files stored in the Special Content (does not include the views),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      and filter MyProject
+        /// will be given a keyword using the name of the zip file (without the .zip extension)
+        /// This helps to organize and filter the multiple files into separate projects.
+        /// </summary>
+        [HttpGet, Route("~/InstallPyScriptProject")]
+        public ActionResult InstallPyScriptProject()
+        {
+            var m = new PythonScriptModel(CurrentDatabase);
+            var script = m.FetchScript("InstallPyScriptProject");
+            if (!script.HasValue())
+            {
+                script = System.IO.File.ReadAllText(Server.MapPath("/Content/InstallPyScriptProject.py"));
+            }
+            if (!PythonScriptModel.CanRunScript(script))
+            {
+                return Message("Not Authorized to run this script");
+            }
+            return Redirect("/PyScriptForm/InstallPyScriptProject");
+        }
+    }
 }

--- a/CmsWeb/Models/SqlScriptModel.cs
+++ b/CmsWeb/Models/SqlScriptModel.cs
@@ -4,9 +4,11 @@ using Dapper;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
+using System.Web.Configuration;
 using System.Web.Mvc;
 using UtilityExtensions;
 
@@ -129,7 +131,7 @@ namespace CmsWeb.Models
         public string FetchScript(string name)
         {
 #if DEBUG
-            name = ParseDebuggingName(name);
+            DebugScriptsHelper.LocateLocalFileInPath(Db, name, ".sql");
 #endif
             var script = Db.ContentOfTypeSql(name);
             return script;
@@ -145,28 +147,5 @@ namespace CmsWeb.Models
             }
             return p;
         }
-#if DEBUG
-        public string ParseDebuggingName(string name)
-        {
-            var runfromUrlRe = new Regex(@"([c-e]![\w-]*-)(\w*)\.sql(-kw-([^/]*)){0,1}");
-            if (runfromUrlRe.IsMatch(name))
-            {
-                var match = runfromUrlRe.Match(name);
-                var debuggingName = match.Groups[0].Value;
-                var contentName = match.Groups[2].Value;
-                var runFromPath = match.Groups[1].Value
-                                  .Replace("!", ":\\")
-                                  .Replace("-", "\\")
-                              + contentName + ".sql";
-                var keyword = match.Groups[4].Value;
-                var script = System.IO.File.ReadAllText(runFromPath);
-
-                Db.WriteContentSql(contentName, script, keyword);
-                return contentName;
-            }
-
-            return name;
-        }
-#endif
     }
 }


### PR DESCRIPTION

## Debugging Python with LocalFile
### method LocateLocalFileInPath
This method facilitates developing and debugging Python Projects involving multiple file types.
It is intended to be run within Visual Studio against a local database.
However, while not recommended, it will also work with a ConnectionString to a production database.
It is designed to allow you to edit every file locally with your favorite code editor.
I prefer Visual Studio Code rather than mixing in with the normal Visual Studio.

To debug a Python script:
- You must uncheck the *Enable Just My Code* setting
   in Tools>Options>Debugging/General area (requires restart I think).
 - You must open the file being debugged in the Visual Studio running bvcms.
 - You do not need to copy the file to the bvcms project however.  Just open it from Visual Studio. This way, every change made in Visual Studio Code, will automatically ask to propagate changes to the file open in Visual Studio.
- You must be in Debug mode.
- You will need to add two settings in your AppSettings:
   - `<add key="LocalScriptsPath" value="c:/dev/MyProject"/>`
   -  `<add key="LocalScriptsContentKeyword" value="MyProject"/>`
   `MyProject` would be the name of your project, which should not conflict with any other project.
   `LocalScriptsPath` is the place you add all of your project files in any Directory structure you want.
   `LocalScriptsContentKey` is the keyword used in Special Content to filter just your project.
   
   I use a `secrets.config` file so as to not accidentally commit that setting to the GitHub repo via the `web.config` file.  

Having these requirements satisfied, you can set breakpoints and examine variables. Unfortunately, global variables outside of a function `def` are not able to be inspected. To get around this, I pass any global variable I need to inspect as a function argument and inspect the parameter there. Of course, you can always use Python's `print` statement.

`LocalLocalFileInPath` serves two purposes:
 1. It finds the full path of the file and writes the file's text into the appropriate Special Content folder
        using the extension-less name of the file with the keyword attached for filtering.
 2. Additionally, if the file is a Python script, 
        it will allow the file run the file in debug mode assuming all of the above requirements are set.

Basically, this function works from three locations:
* `CmsWeb/Models/PythonScriptModel.cs` -- `FetchScript(name)` method
* `CmsWeb/Models/SqlScriptModel.cs` -- `FetchScript(name)` method
* `CMSData/API/PythonModel/PythonModel.Misc.cs` -- `Content(name)` method

## Installation by Uploading Zip file
### method InstallPyScriptProject
This method will allow an Admin to install a Python project
with many files of different types stored in a zip file.

The zip file should be outside of you scripts folder so as to not be recursive.

The files can be any of the following types:
- \*.view.sql -- installs in the database as a custom view.
    These view files should be numbered with leading digits so as to install in that order.
    The ordering is important if any view depends on another view.
    If there are no dependencies, then the leading digits are not necessary.
    The name of the view will be the name of the file excluding the leading digits and the extensions.
- \*.text.html -- this is an html file stored as a text file (easier to edit that way)
- \*.sql -- A SQL report
- \*.py -- A python script
- \*.json -- stored as text, but can be parsed and used in a view
- \*.html -- stored as html and uses the html editor
- Install.py -- This is optional and is not stored in the database.
  It runs once after all files/views are installed and is used when custom initialization is required.

It is **required** that all files have unique names when the extension is removed,
that is, you cannot have `MyProjectRunReport.py` and `MyProjectRunReport.sql`.

Also, it is **required** to prefix every file and view with a unique name.
This allows the files to be grouped together and not clobber files of the same name during installation.

Any folder hierarchy is ignored.

All files will be stored in the Special Content (does not include the views), 
and your files will be given a keyword using the name of the zip file 
(without the .zip extension, `MyProject` in this example)
This helps to organize and filter the multiple files into separate projects.