### PR TITLE
Acceptiva country code fix

### DIFF
--- a/CmsData/Finance/AcceptivaGateway.cs
+++ b/CmsData/Finance/AcceptivaGateway.cs
@@ -183,8 +183,8 @@ namespace CmsData.Finance
                     Address = addr,
                     Address2 = addr2,
                     City = city,
-                    State = state,
-                    Country = country,
+                    State = UPSStateCodes.FromStateCountry(state, country, db) ?? state,
+                    Country = ISO3166.Alpha3FromName(country) ?? country,
                     Zip = zip,
                     Email = email,
                     Phone = phone

--- a/IntegrationTests/Areas/OnlineReg/OneTimeGivingTests.cs
+++ b/IntegrationTests/Areas/OnlineReg/OneTimeGivingTests.cs
@@ -26,8 +26,8 @@ namespace IntegrationTests.Areas.OnlineReg
             Open($"{rootUrl}Person2/{user.PeopleId}");
             WaitForPageLoad();
             Find(css: @"a[href=""#giving""]").Click();
+            Wait(1);
             WaitForElementToDisappear(loadingUI);
-            Wait(2);
 
             Find(text: "Make a One Time Gift").Click();
             Wait(3);

--- a/UnitTests/CmsDataTests/CmsDataTests.csproj
+++ b/UnitTests/CmsDataTests/CmsDataTests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="DbUtil\CMSDataContextTests.cs" />
     <Compile Include="Extensions\ContributionTests.cs" />
     <Compile Include="Finance\AcceptivaGatewayTests.cs" />
+    <Compile Include="Finance\Acceptiva\Core\Helpers\ISO3166Tests.cs" />
     <Compile Include="Generated\CMSDataContextFunctionTests.cs" />
     <Compile Include="Organization\OrganizationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UnitTests/CmsDataTests/Finance/Acceptiva/Core/Helpers/ISO3166Tests.cs
+++ b/UnitTests/CmsDataTests/Finance/Acceptiva/Core/Helpers/ISO3166Tests.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+using Shouldly;
+using CmsData.Finance.Acceptiva.Core;
+using System.Linq;
+
+namespace CmsDataTests.Finance.Acceptiva.Core
+{
+    public class ISO3166Tests
+    {
+        [Theory]
+        [InlineData("United States")]
+        [InlineData("Canada")]
+        [InlineData("Mexico")]
+        public void Should_Return_Country_Code(string country)
+        {
+            var code = ISO3166.Alpha3FromName(country);
+            code.ToCharArray().Count().ShouldBe(3);
+        }
+    }
+}


### PR DESCRIPTION
Convert Country to ISO Codes and States to UPS Code which is necessary to complete an Acceptiva ACH transaction.

https://trello.com/c/qV0UdIfh/5295-custom-dev-build-integration-to-acceptiva-for-payment-processing-for-st-ann-parish