### PR TITLE
Mission Trip Support Link Fix

### DIFF
--- a/CmsWeb/Areas/OnlineReg/Controllers/OnlineRegController.cs
+++ b/CmsWeb/Areas/OnlineReg/Controllers/OnlineRegController.cs
@@ -596,7 +596,9 @@ namespace CmsWeb.Areas.OnlineReg.Controllers
             {
                 m.URL = CurrentDatabase.ServerLink($"/OnlineReg/{id}/Giving/{goerid}");
             }
-            if (Util.UserPeopleId == goerid)
+
+            var currentUserId = Util.UserPeopleId;
+            if (currentUserId != null && currentUserId == goerid)
             {
                 return View("Giving/Goer", m);
             }


### PR DESCRIPTION
Validates current user id is not null to return support page instead of fundraising page.