### PR TITLE
Keep the enrollment date after dropping an organization member.

### DIFF
--- a/CmsData/Organization/OrganizationMember.cs
+++ b/CmsData/Organization/OrganizationMember.cs
@@ -45,6 +45,7 @@ namespace CmsData
                     PeopleId = PeopleId,
                     MemberTypeId = MemberTypeId,
                     OrganizationName = orgname,
+                    EnrollmentDate = EnrollmentDate, //Adding Enrollment Date to show on the system after droppíng member.
                     TransactionDate = dropdate,
                     TransactionTypeId = 5, // drop
                     CreatedBy = Util.UserId1,


### PR DESCRIPTION
Enrollment date is not kept after executing member drop . 
Assigning value to the property fixes it.