### PR TITLE
TPD-611 Vital Stats Graphs Error

### DIFF
--- a/CmsData/Extensions/Contribution.cs
+++ b/CmsData/Extensions/Contribution.cs
@@ -126,10 +126,11 @@ namespace CmsData
                 && (!includeReturnedReversed ? c.ContributionStatusId != ContributionStatusCode.Returned : 1 == 1)
                 && (!includeReturnedReversed ? c.ContributionStatusId != ContributionStatusCode.Reversed : 1 == 1)
                 && (!includePledges ? c.ContributionTypeId != ContributionTypeCode.Pledge : 1 == 1)
+                && (c.ContributionDate != null)
 
                 select c
                    );
-            return (fundids.IsNotNull()) ? q.Where(x => fundids.Contains(x.FundId)).ToList() : q.Where(c => c.ContributionDate != null).ToList();
+            return (fundids.IsNotNull()) ? q.Where(x => fundids.Contains(x.FundId)).ToList() : q.ToList();
         }
 
         public static List<Contribution> GetContributionsPerYear(CMSDataContext db, int? year, int[] fundids = null, bool includeReturnedReversed = false, bool includePledges = false)

--- a/CmsData/Extensions/Contribution.cs
+++ b/CmsData/Extensions/Contribution.cs
@@ -129,7 +129,7 @@ namespace CmsData
 
                 select c
                    );
-            return (fundids.IsNotNull()) ? q.Where(x => fundids.Contains(x.FundId)).ToList() : q.ToList();
+            return (fundids.IsNotNull()) ? q.Where(x => fundids.Contains(x.FundId)).ToList() : q.Where(c => c.ContributionDate != null).ToList();
         }
 
         public static List<Contribution> GetContributionsPerYear(CMSDataContext db, int? year, int[] fundids = null, bool includeReturnedReversed = false, bool includePledges = false)


### PR DESCRIPTION
fixed bug by excluding contribution records with no contribution date. Contribution date in the Contribution table is not null able in the db. Theoretically, therefore, should be no records with  null contribution date. There is one record in the training db in the contribution table with a null in the contribution date.