### PR TITLE
TPD-554-Deceased-records-allowed-set-to-recurring

### DIFF
--- a/CmsWeb/Areas/Manage/Models/AccountModel.cs
+++ b/CmsWeb/Areas/Manage/Models/AccountModel.cs
@@ -274,7 +274,7 @@ namespace CmsWeb.Models
                 (uu.Username == userName ||
                 uu.Person.EmailAddress == userName ||
                 uu.Person.EmailAddress2 == userName) &&
-                uu.Person.Deceased != true
+                uu.Person.DeceasedDate == null
                 );
 
             var impersonating = false;

--- a/CmsWeb/Areas/Manage/Models/AccountModel.cs
+++ b/CmsWeb/Areas/Manage/Models/AccountModel.cs
@@ -271,9 +271,10 @@ namespace CmsWeb.Models
         public static UserValidationResult AuthenticateLogon(string userName, string password, string url, CMSDataContext db)
         {
             var userQuery = db.Users.Where(uu =>
-                uu.Username == userName ||
+                (uu.Username == userName ||
                 uu.Person.EmailAddress == userName ||
-                uu.Person.EmailAddress2 == userName
+                uu.Person.EmailAddress2 == userName) &&
+                uu.Person.Deceased == false
                 );
 
             var impersonating = false;

--- a/CmsWeb/Areas/Manage/Models/AccountModel.cs
+++ b/CmsWeb/Areas/Manage/Models/AccountModel.cs
@@ -274,7 +274,7 @@ namespace CmsWeb.Models
                 (uu.Username == userName ||
                 uu.Person.EmailAddress == userName ||
                 uu.Person.EmailAddress2 == userName) &&
-                uu.Person.Deceased == false
+                uu.Person.Deceased != true
                 );
 
             var impersonating = false;


### PR DESCRIPTION
I changed AuthenticeLogon function to require uu.Person.Deceased == true. If false, this user cannot login. The one question I have is should we do something about the error message? Currently, the error message will say "bad database"