### PR TITLE
TPD-778 Recurring giving stopped should not send confirmation email

### DIFF
--- a/CmsWeb/Areas/OnlineReg/Models/ManageGivingModel.cs
+++ b/CmsWeb/Areas/OnlineReg/Models/ManageGivingModel.cs
@@ -686,7 +686,7 @@ namespace CmsWeb.Areas.OnlineReg.Models
 
         public string AutocompleteOnOff => Util.IsDebug() ? "on" : "off";
 
-        public bool ManagedGivingStopped { get; private set; }        
+        public bool ManagedGivingStopped { get; set; }
 
         public void CancelManagedGiving(int peopleId)
         {


### PR DESCRIPTION
https://touchpointsoftware.atlassian.net/browse/TPD-778
During deserialization of the ManageGivingModel, it was unable to set the value of the ManagedGivingStopped property so it was always false.