### PR TITLE
TPD-892 - Fixed Bundle creation redirect issue and added unit test

### DIFF
--- a/CmsWeb/Areas/Finance/Controllers/BundleController.cs
+++ b/CmsWeb/Areas/Finance/Controllers/BundleController.cs
@@ -22,7 +22,12 @@ namespace CmsWeb.Areas.Finance.Controllers
         public ActionResult Index(int id, bool? create, bool? edit)
         {
             var m = new Models.BundleModel(id, CurrentDatabase);
-            ViewBag.createbundle = create;
+
+            if (TempData["BundleCreated"] == null)
+                ViewBag.createbundle = create;
+
+            TempData["BundleCreated"] = "True";
+
             ViewBag.editbundle = edit;
             if (User.IsInRole("FinanceDataEntry") && m.BundleStatusId != BundleStatusCode.OpenForDataEntry)
             {
@@ -102,7 +107,8 @@ namespace CmsWeb.Areas.Finance.Controllers
             }
 
             m.BundleId = id; // refresh values
-            return View("Display", m);
+
+            return Redirect($"/Bundle/{id}?create=false");
         }
 
         [HttpPost]

--- a/CmsWeb/Areas/Finance/Controllers/BundleController.cs
+++ b/CmsWeb/Areas/Finance/Controllers/BundleController.cs
@@ -28,6 +28,8 @@ namespace CmsWeb.Areas.Finance.Controllers
                 return Content("no bundle");
             }
 
+            ViewBag.editbundle = edit;
+
             // Since this action gets called more than once in succession sometimes, make sure Bundle
             //     was not created first.
             if (create == true &&
@@ -36,7 +38,6 @@ namespace CmsWeb.Areas.Finance.Controllers
                 m.Bundle.TotalEnvelopes == null)
             {
                 ViewBag.createbundle = create;
-                ViewBag.editbundle = edit;
 
                 if (User.IsInRole("FinanceDataEntry") && m.BundleStatusId != BundleStatusCode.OpenForDataEntry)
                 {
@@ -119,6 +120,7 @@ namespace CmsWeb.Areas.Finance.Controllers
         public ActionResult Cancel(int id)
         {
             var m = new Models.BundleModel(id, CurrentDatabase);
+
             return View("Display", m);
         }
 

--- a/CmsWeb/Areas/Finance/Controllers/BundleController.cs
+++ b/CmsWeb/Areas/Finance/Controllers/BundleController.cs
@@ -23,20 +23,25 @@ namespace CmsWeb.Areas.Finance.Controllers
         {
             var m = new Models.BundleModel(id, CurrentDatabase);
 
-            if (TempData["BundleCreated"] == null)
-                ViewBag.createbundle = create;
-
-            TempData["BundleCreated"] = "True";
-
-            ViewBag.editbundle = edit;
-            if (User.IsInRole("FinanceDataEntry") && m.BundleStatusId != BundleStatusCode.OpenForDataEntry)
-            {
-                return Redirect("/Bundles");
-            }
-
-            if (m.Bundle == null)
+            if (m == null || m.Bundle == null)
             {
                 return Content("no bundle");
+            }
+
+            // Since this action gets called more than once in succession sometimes, make sure Bundle
+            //     was not created first.
+            if (create == true &&
+                m.Bundle.TotalCash == null &&
+                m.Bundle.TotalChecks == null &&
+                m.Bundle.TotalEnvelopes == null)
+            {
+                ViewBag.createbundle = create;
+                ViewBag.editbundle = edit;
+
+                if (User.IsInRole("FinanceDataEntry") && m.BundleStatusId != BundleStatusCode.OpenForDataEntry)
+                {
+                    return Redirect("/Bundles");
+                }
             }
 
             return View(m);
@@ -107,8 +112,7 @@ namespace CmsWeb.Areas.Finance.Controllers
             }
 
             m.BundleId = id; // refresh values
-
-            return Redirect($"/Bundle/{id}?create=false");
+            return Redirect($"/Bundle/{id}");
         }
 
         [HttpPost]

--- a/CmsWeb/Areas/Finance/Views/Bundle/Edit.cshtml
+++ b/CmsWeb/Areas/Finance/Views/Bundle/Edit.cshtml
@@ -88,7 +88,8 @@
                         </li>
                     </ul>
                     <div class="hidden-xs">
-                        <a href="/Bundle/Cancel/@Model.BundleId" class="btn btn-default displayedit">Cancel</a> <a href="/Bundle/Update/@Model.BundleId" class="btn btn-primary displayedit">Save</a>
+                        <a href="/Bundle/@Model.BundleId" class="btn btn-default">Cancel</a>
+                        <a href="/Bundle/Update/@Model.BundleId" class="btn btn-primary displayedit">Save</a>
                     </div>
                     <div class="visible-xs-block">
                         <a href="/Bundle/Update/@Model.BundleId" class="btn btn-primary displayedit btn-block">Save</a>

--- a/CmsWeb/Areas/Manage/Controllers/BatchController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/BatchController.cs
@@ -337,8 +337,13 @@ namespace CmsWeb.Areas.Manage.Controllers
         {
             var rg = (from r in CurrentDatabase.ManagedGivings
                       where r.PeopleId == id
-                      select r).Single();
-            rg.DoGiving(CurrentDatabase);
+                      select r).SingleOrDefault();
+
+            if (rg != null)
+            {
+                rg.DoGiving(CurrentDatabase);
+            }
+
             return Content($"done with {id}");
         }
 

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -45,7 +45,7 @@
     <!-- use (local) or .\SQLEXPRESS -->
     <add key="dbserver" value="" />
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="myBvcms" />
+    <add key="host" value="" />
     <!--Pushpay Authentication-->
     <add key="PushpayAPIBaseUrl" value="https://sandbox-api.pushpay.io/v1/" />
     <add key="PushpayClientID" value="pursuant-touchpoint-dev" />
@@ -1033,7 +1033,7 @@
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">
-        <specifiedPickupDirectory pickupDirectoryLocation="c:\dev\pursuant\email" />
+        <specifiedPickupDirectory pickupDirectoryLocation="c:\email" />
         <network host="localhost" />
       </smtp>
       <!--<smtp from="somebody@nowhere.com">

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -45,7 +45,7 @@
     <!-- use (local) or .\SQLEXPRESS -->
     <add key="dbserver" value="" />
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="" />
+    <add key="host" value="myBvcms" />
     <!--Pushpay Authentication-->
     <add key="PushpayAPIBaseUrl" value="https://sandbox-api.pushpay.io/v1/" />
     <add key="PushpayClientID" value="pursuant-touchpoint-dev" />
@@ -650,10 +650,10 @@
   </location>
   <location path="Pushpay/ProcessPayment">
     <system.web>
-        <authorization>
-            <allow users="*" />
-            <allow users="?" />
-        </authorization>
+      <authorization>
+        <allow users="*" />
+        <allow users="?" />
+      </authorization>
     </system.web>
   </location>
   <!--
@@ -1033,7 +1033,7 @@
   <system.net>
     <mailSettings>
       <smtp deliveryMethod="SpecifiedPickupDirectory">
-        <specifiedPickupDirectory pickupDirectoryLocation="c:\email" />
+        <specifiedPickupDirectory pickupDirectoryLocation="c:\dev\pursuant\email" />
         <network host="localhost" />
       </smtp>
       <!--<smtp from="somebody@nowhere.com">

--- a/IntegrationTests/Areas/Finance/Views/PostBundle/PostBundleViewsTests.cs
+++ b/IntegrationTests/Areas/Finance/Views/PostBundle/PostBundleViewsTests.cs
@@ -49,5 +49,31 @@ namespace IntegrationTests.Areas.Finance.Views.PostBundle
             var r6 = Find(css: "tr:nth-child(6) > .name");
             r6.ShouldNotBeNull();
         }
+
+        /// <summary>
+        /// Tests creation of a Bundle. After clicking "Save", there
+        ///     should be a redirect to the next (summary) page.
+        /// </summary>
+        [Fact]
+        public void Should_Redirect_After_Creating_Bundle()
+        {
+            username = RandomString();
+            password = RandomString();
+            var user = CreateUser(username, password, roles: new string[] { "Access", "Edit", "Admin", "Finance" });
+            Login();
+            Wait(3);
+            Open($"{rootUrl}Bundles/");
+            Find(text: "Create New Bundle").Click();
+            Find(id: "Bundle_TotalCash").SendKeys("100");
+            Find(id: "Bundle_TotalChecks").SendKeys("500");
+            Find(id: "Bundle_TotalEnvelopes").SendKeys("25");
+            var noResults = Find(id: "results");
+            noResults.ShouldBeNull();
+            Find(text: "Save").Click();
+            Wait(4);
+            var results = Find(id: "results");
+            results.ShouldNotBeNull();
+        }
+
     }
 }


### PR DESCRIPTION
Previously when creating a new Bundle (Administration > Bundles > click "Create New Bundle" button > fill out fields > click "Save"), the page would just redirect back to itself, instead of advancing to the confirmation page.  This was due to the querystring in the redirect somehow resetting the "create" parameter to "true", even if explicitly set to false in the redirect statement executed right after the Bundle is saved.  So I added a "sentinel" using TempData to maintain the state of "Bundle Created" to prevent the faulty redirect.
touchpointsoftware.atlassian.net/browse/TPD-892