### PR TITLE
TPD-910 - added thumbnail creation to Example Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ CmsWeb/StagingConnectionStrings.config
 cassette-cache/
 CmsDataSqlClr.dbmdl
 CmsWeb/Upload/
+Web.config
 Web.*.config
 CmsDataSqlClr_.*.sqlproj
 

--- a/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
+++ b/CmsWeb/Areas/Manage/Controllers/DisplayController.cs
@@ -171,8 +171,27 @@ namespace CmsWeb.Areas.Manage.Controllers
 
             var bodytemplate = new { design = unlayerDesign, rawHtml = GetBody(body) };
             content.Body = JsonConvert.SerializeObject(bodytemplate);
-            
-            content.DateCreated = DateTime.Now;
+
+            if (content.TypeID == ContentTypeCode.TypeUnlayerTemplate)
+            {
+                try
+                {
+                    var captureWebPageBytes = CaptureWebPageBytes(body, 100, 150);
+                    var ii = CurrentImageDatabase.UpdateImageFromBits(content.ThumbID, captureWebPageBytes);
+                    if (ii == null)
+                    {
+                        content.ThumbID = ImageData.Image.NewImageFromBits(captureWebPageBytes, CurrentImageDatabase).Id;
+                    }
+
+                    content.DateCreated = DateTime.Now;
+                    content.CreatedBy = Util.UserName;
+                }
+                catch (Exception ex)
+                {
+                    var errorLog = ErrorLog.GetDefault(null);
+                    errorLog.Log(new Error(ex));
+                }
+            }
 
             if (!saveid.HasValue || saveid == 0)
             {

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -650,10 +650,10 @@
   </location>
   <location path="Pushpay/ProcessPayment">
     <system.web>
-        <authorization>
-            <allow users="*" />
-            <allow users="?" />
-        </authorization>
+      <authorization>
+        <allow users="*" />
+        <allow users="?" />
+      </authorization>
     </system.web>
   </location>
   <!--

--- a/IntegrationTests/Areas/Main/Views/Email/EmailViewsTests.cs
+++ b/IntegrationTests/Areas/Main/Views/Email/EmailViewsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using CMSWebTests;
 using System.Data.Linq;
 using System.Drawing;
+using ImageData;
 
 namespace IntegrationTests.Areas.Main.Views.Email
 {
@@ -45,6 +46,25 @@ namespace IntegrationTests.Areas.Main.Views.Email
             Wait(5);
 
             driver.PageSource.ShouldContain("<h2>Email has completed.</h2>");
+        }
+
+        [Fact]
+        public void SaveUnlayerTemplate_Should_Create_Thumbnail()
+        {
+            var db = CMSImageDataContext.Create(DatabaseFixture.Host);
+            db.ExecuteCommand("DELETE FROM Image");
+
+            username = RandomString();
+            password = RandomString();
+            var user = CreateUser(username, password, roles: new string[] { "Admin", "Edit", "Access", "Checkin" });
+            Login();
+            Wait(3);
+            Open($"{rootUrl}Display/#tab_emailTemplates");
+            Find(text: "Example Template").Click();
+            Find(id: "SaveTemplateButton").Click();
+            Wait(3);
+
+            db.Images.ShouldNotBeEmpty();
         }
     }
 }


### PR DESCRIPTION
The Example Template (one to the far right) has the property IsUnLayer = true, unlike the other three templates.  This causes UnLayerCompose.cshtml to be rendered, rather than EditTemplate.cshtml like the others.

UnLayerCompose.cshtml calls DisplayController.cs > SaveUnlayerTemplate() when the “Save Template” button is clicked.  The other three templates call DisplayController.cs > ContentUpdate() instead.  That is why they all work (thumbnail image is created and displayed) whereas the Example Template link isn’t working.

So I added the image creation code to SaveUnlayerTemplate like the ContentUpdate method has.

Jira card: https://touchpointsoftware.atlassian.net/secure/RapidBoard.jspa?rapidView=6&projectKey=TPD&selectedIssue=TPD-892&assignee=5e9da7220d58350c2be09a8f

[touchpointsoftware.atlassian.net/browse/TPD-910](https://touchpointsoftware.atlassian.net/browse/TPD-910)